### PR TITLE
ci: switch back to deploy_to_branch

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -27,13 +27,8 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4.2.3
-        with:
-          branch: gh-pages
-          folder: .
-          clean: false
+      - name: Deploy to gh-pages branch
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
I didn't notice sooner that `JamesIves/github-pages-deploy-action@v4.2.3` action publishes whole repository to `gh-pages`.

### Changes
Improves #7 & #21

### How to test
[Run workflow manually](https://github.com/Appsilon/rhino/actions/workflows/pkgdown.yaml) and confirm [gh-pages](https://github.com/Appsilon/rhino/tree/gh-pages) has no directory other than `reference`.