### PR TITLE
feat: Enable interactive mode for Cypress.

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -122,7 +122,11 @@ lint_sass <- function() {
 
 #' Run Cypress end-to-end tests
 #'
+#' @param interactive Should Cypress be run in the interactive mode?
+#'
 #' @export
-test_e2e <- function() {
-  yarn("test-e2e")
+test_e2e <- function(interactive = FALSE) {
+  command <- ifelse(isTRUE(interactive), "test-e2e-interactive", "test-e2e")
+
+  yarn(command)
 }

--- a/inst/templates/node/package.json
+++ b/inst/templates/node/package.json
@@ -7,7 +7,9 @@
     "lint-sass": "stylelint root/app/styles",
     "run-app": "cd root && Rscript -e 'shiny::runApp(port = 3333)'",
     "run-cypress": "cypress run --project root/tests",
-    "test-e2e": "start-server-and-test run-app http://localhost:3333 run-cypress"
+    "open-cypress": "cypress open --project root/tests",
+    "test-e2e": "start-server-and-test run-app http://localhost:3333 run-cypress",
+    "test-e2e-interactive": "start-server-and-test run-app http://localhost:3333 open-cypress"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/man/test_e2e.Rd
+++ b/man/test_e2e.Rd
@@ -4,7 +4,10 @@
 \alias{test_e2e}
 \title{Run Cypress end-to-end tests}
 \usage{
-test_e2e()
+test_e2e(interactive = FALSE)
+}
+\arguments{
+\item{interactive}{Should Cypress be run in the interactive mode?}
 }
 \description{
 Run Cypress end-to-end tests


### PR DESCRIPTION
### Changes
Closes #75 

### How to test
Run `test_e2e(interactive = TRUE)`. It should trigger interactive version of Cypress.