### PR TITLE
Improve .Rproj template

### DIFF
--- a/inst/templates/app_structure/app.Rproj.template
+++ b/inst/templates/app_structure/app.Rproj.template
@@ -1,7 +1,7 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
+RestoreWorkspace: No
+SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
@@ -11,3 +11,7 @@ Encoding: UTF-8
 
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix


### PR DESCRIPTION
### Changes
1. Improve default settings in our `.Rproj` template.
2. Rename `src.Rproj` to `app.Rproj` (we used to have an `src` directory, but it no longer makes sense).

### How to test
Initialize a project and see if you can open it in RStudio.