### PR TITLE
Improve styler

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -35,7 +35,7 @@ rhino_style <- function() {
 #' @param paths Character vector of files and directories to format.
 #'
 #' @export
-format_r <- function(paths = c("app", "tests")) {
+format_r <- function(paths) {
   for (path in paths) {
     if (fs::is_dir(path)) {
       styler::style_dir(path, style = rhino_style)

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -4,7 +4,7 @@
 \alias{format_r}
 \title{Format R}
 \usage{
-format_r(paths = c("app", "tests"))
+format_r(paths)
 }
 \arguments{
 \item{paths}{Character vector of files and directories to format.}


### PR DESCRIPTION
### Changes
Closes #70:
1. Use `styler::tidyverse_style()` but don't touch spacing around operators at all.
2. Allow to style multiple files/directories with a single call to `format_r()`.
3. Style `app` and `tests` by default.

Change (3) might be somewhat controversial. We wanted to force the user to be explicit about the files to be formatted, as we felt that styler is somewhat flawed and perhaps only useful when inheriting a lot of ill-formatted legacy code.

I suggest that we provide a default argument anyway. It can encourage users to run `format_r()` more often, hopefully giving us more feedback in what situations it's too aggressive / inconsistent with `lint_r()`. It is still a completely optional tool. @jakubnowicki @tmakowski please weigh in.

### How to test
Initialize a project and run `format_r()`. No files should be modified. Play around with spacing around operators and rerun the tool.