### PR TITLE
Fix URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 0.6.2
+Version: 0.6.3
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
     person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
   )
 Description: A framework that supports creating and extending enterprise Shiny applications using best practices.
-URL: https://appsilon.github.io/rhino, https://github.com/Appsilon/rhino
+URL: https://appsilon.github.io/rhino/, https://github.com/Appsilon/rhino
 BugReports: https://github.com/Appsilon/rhino/issues
 License: LGPL-3
 Encoding: UTF-8

--- a/vignettes/rhino-project-structure.Rmd
+++ b/vignettes/rhino-project-structure.Rmd
@@ -77,7 +77,7 @@ R comes with the `library()` and `source()` functions,
 but its functionality is limited when it comes
 to dividing your code into modules and expressing their dependencies.
 
-To address this, Rhino uses the [box](https://klmr.me/box) R package,
+To address this, Rhino uses the [box](https://klmr.me/box/) R package,
 which allows you to modularize your code in a similar way to languages like Python and Java:
 ```r
 box::use(
@@ -89,7 +89,7 @@ box::use(
 )
 ```
 
-The best place to learn about box is its official [documentation](https://klmr.me/box).
+The best place to learn about box is its official [documentation](https://klmr.me/box/).
 Some useful box features are also explained in the sections below.
 
 ## `__init__.R` files


### PR DESCRIPTION
### Changes
1.  Add trailing slashes to avoid `R CMD check` "errors".
    ```
      Found the following (possibly) invalid URLs:
        URL: https://appsilon.github.io/rhino (moved to https://appsilon.github.io/rhino/)
          From: DESCRIPTION
          Status: 200
          Message: OK
        URL: https://klmr.me/box (moved to https://klmr.me/box/)
          From: inst/doc/rhino-project-structure.html
          Status: 200
          Message: OK
    ```
2. Bump version to 0.6.3.
