### PR TITLE
Add trivial examples to all exported functions

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -81,6 +81,12 @@ with_head_tags <- function(ui) {
 #'
 #' @return An object representing the app (can be passed to `shiny::runApp()`).
 #'
+#' @examples
+#' \dontrun{
+#'   # Your `app.R` should contain nothing but this single call:
+#'   rhino::app()
+#' }
+#'
 #' @export
 app <- function() {
   configure_logger()

--- a/R/rhino.R
+++ b/R/rhino.R
@@ -65,6 +65,12 @@ system_cmd_version <- function(cmd) {
 #'
 #' @return None. This function is called for side effects.
 #'
+#' @examples
+#' if (interactive()) {
+#'   # Print diagnostic information.
+#'   diagnostics()
+#' }
+#'
 #' @export
 diagnostics <- function() {
   writeLines(c(

--- a/R/tools.R
+++ b/R/tools.R
@@ -4,6 +4,12 @@
 #'
 #' @return None. This function is called for side effects.
 #'
+#' @examples
+#' if (interactive()) {
+#'   # Run all unit tests in the `tests/testthat` directory.
+#'   test_r()
+#' }
+#'
 #' @export
 test_r <- function() {
   testthat::test_dir(fs::path("tests", "testthat"))
@@ -18,6 +24,15 @@ test_r <- function() {
 #'
 #' @param accepted_errors Number of accepted style errors.
 #' @return None. This function is called for side effects.
+#'
+#' @examples
+#' if (interactive()) {
+#'   # Lint all R sources in the `app` and `tests/testthat` directories.
+#'   lint_r()
+#'
+#'   # Accept up to 10 errors:
+#'   lint_r(accepted_errors = 10)
+#' }
 #'
 #' @export
 lint_r <- function(accepted_errors = 0) {
@@ -101,6 +116,12 @@ format_r <- function(paths) {
 #' @param watch Keep the process running and rebuilding JS whenever source files change.
 #' @return None. This function is called for side effects.
 #'
+#' @examples
+#' if (interactive()) {
+#'   # Build the `app/js/index.js` file into `app/static/js/app.min.js`.
+#'   build_js()
+#' }
+#'
 #' @export
 build_js <- function(watch = FALSE) {
   if (watch) yarn("build-js", "--watch", status_ok = 2)
@@ -131,6 +152,12 @@ build_js <- function(watch = FALSE) {
 #' @param fix Automatically fix problems.
 #' @return None. This function is called for side effects.
 #'
+#' @examples
+#' if (interactive()) {
+#'   # Lint the JavaScript sources in the `app/js` directory.
+#'   lint_js()
+#' }
+#'
 #' @export
 # nolint end
 lint_js <- function(fix = FALSE) {
@@ -155,6 +182,12 @@ lint_js <- function(fix = FALSE) {
 #' @param watch Keep the process running and rebuilding Sass whenever source files change.
 #' Only supported for `sass: node` configuration in `rhino.yml`.
 #' @return None. This function is called for side effects.
+#'
+#' @examples
+#' if (interactive()) {
+#'   # Build the `app/styles/main.scss` file into `app/static/css/app.min.css`.
+#'   build_sass()
+#' }
 #'
 #' @export
 build_sass <- function(watch = FALSE) {
@@ -184,6 +217,12 @@ build_sass <- function(watch = FALSE) {
 #' @param fix Automatically fix problems.
 #' @return None. This function is called for side effects.
 #'
+#' @examples
+#' if (interactive()) {
+#'   # Lint the Sass sources in the `app/styles` directory.
+#'   lint_sass()
+#' }
+#'
 #' @export
 lint_sass <- function(fix = FALSE) {
   yarn("lint-sass", if (fix) "--fix")
@@ -197,6 +236,12 @@ lint_sass <- function(fix = FALSE) {
 #'
 #' @param interactive Should Cypress be run in the interactive mode?
 #' @return None. This function is called for side effects.
+#'
+#' @examples
+#' if (interactive()) {
+#'   # Run the end-to-end tests in the `tests/cypress` directory.
+#'   test_e2e()
+#' }
 #'
 #' @export
 test_e2e <- function(interactive = FALSE) {

--- a/man/app.Rd
+++ b/man/app.Rd
@@ -49,3 +49,10 @@ into a \href{https://shiny.rstudio.com/articles/modules.html}{Shiny module}
 }
 }
 
+\examples{
+\dontrun{
+  # Your `app.R` should contain nothing but this single call:
+  rhino::app()
+}
+
+}

--- a/man/build_js.Rd
+++ b/man/build_js.Rd
@@ -34,3 +34,10 @@ Instead you should explicitly export functions:\if{html}{\out{<div class="source
 and access them via the global \code{App} object:\if{html}{\out{<div class="sourceCode r">}}\preformatted{tags$button("Hello!", onclick = "App.sayHello()")
 }\if{html}{\out{</div>}}
 }
+\examples{
+if (interactive()) {
+  # Build the `app/js/index.js` file into `app/static/js/app.min.js`.
+  build_js()
+}
+
+}

--- a/man/build_sass.Rd
+++ b/man/build_sass.Rd
@@ -30,3 +30,10 @@ On systems without \code{yarn} you can use the \code{{sass}} R package as a fall
 It is not advised however, as it uses the deprecated
 \href{https://sass-lang.com/blog/libsass-is-deprecated}{LibSass} implementation.
 }
+\examples{
+if (interactive()) {
+  # Build the `app/styles/main.scss` file into `app/static/css/app.min.css`.
+  build_sass()
+}
+
+}

--- a/man/diagnostics.Rd
+++ b/man/diagnostics.Rd
@@ -12,3 +12,10 @@ None. This function is called for side effects.
 \description{
 Prints information which can be useful for diagnosing issues with Rhino.
 }
+\examples{
+if (interactive()) {
+  # Print diagnostic information.
+  diagnostics()
+}
+
+}

--- a/man/lint_js.Rd
+++ b/man/lint_js.Rd
@@ -31,3 +31,10 @@ you can disable a specific rule for the next line of code with a comment like:\i
 See the \href{https://eslint.org/docs/user-guide/configuring/rules#using-configuration-comments-1}{ESLint documentation}
 for full details.
 }
+\examples{
+if (interactive()) {
+  # Lint the JavaScript sources in the `app/js` directory.
+  lint_js()
+}
+
+}

--- a/man/lint_r.Rd
+++ b/man/lint_r.Rd
@@ -19,3 +19,13 @@ for style errors.
 \details{
 The linter rules can be adjusted in the \code{.lintr} file.
 }
+\examples{
+if (interactive()) {
+  # Lint all R sources in the `app` and `tests/testthat` directories.
+  lint_r()
+
+  # Accept up to 10 errors:
+  lint_r(accepted_errors = 10)
+}
+
+}

--- a/man/lint_sass.Rd
+++ b/man/lint_sass.Rd
@@ -16,3 +16,10 @@ None. This function is called for side effects.
 Runs \href{https://stylelint.io/}{Stylelint} on the Sass sources in the \code{app/styles} directory.
 Requires Node.js and the \code{yarn} command to be available on the system.
 }
+\examples{
+if (interactive()) {
+  # Lint the Sass sources in the `app/styles` directory.
+  lint_sass()
+}
+
+}

--- a/man/test_e2e.Rd
+++ b/man/test_e2e.Rd
@@ -17,3 +17,10 @@ Uses \href{https://www.cypress.io/}{Cypress} to run end-to-end tests
 defined in the \code{tests/cypress} directory.
 Requires Node.js and the \code{yarn} command to be available on the system.
 }
+\examples{
+if (interactive()) {
+  # Run the end-to-end tests in the `tests/cypress` directory.
+  test_e2e()
+}
+
+}

--- a/man/test_r.Rd
+++ b/man/test_r.Rd
@@ -12,3 +12,10 @@ None. This function is called for side effects.
 \description{
 Uses the \code{{testhat}} package to run all unit tests in \code{tests/testthat} directory.
 }
+\examples{
+if (interactive()) {
+  # Run all unit tests in the `tests/testthat` directory.
+  test_r()
+}
+
+}


### PR DESCRIPTION
### Changes
Closes #152. Using `\dontrun{}` simply adds `if (FALSE)`. I decided to use it for `rhino::app()` and `if (interactive())` for all other functions (seems closer to the goal).
