### PR TITLE
fix: Fix missing curl dependency,

### DIFF
--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           r-version: ${{ env.R_VERSION }}
 
+      - name: Setup system dependencies
+        run: >
+          sudo apt-get install --yes
+          libcurl4-openssl-dev
+
       - name: Restore renv from cache
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
### Changes
Bugfix - adds missing system dependency required by the `curl` package.

### How to test
Create a new Rhino application and push it to a GitHub repository. CI should pass.

Example:
https://github.com/jakubnowicki/test_rhino_ci/actions