### PR TITLE
Introduce the config package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Depends:
 Imports:
   box,
   cli,
+  config,
   fs,
   glue,
   lintr (>= 2.0.0),

--- a/R/app.R
+++ b/R/app.R
@@ -1,6 +1,7 @@
 configure_logger <- function() {
-  log_level <- Sys.getenv("LOG_LEVEL", unset = "INFO")
-  log_file <- Sys.getenv("LOG_FILE", unset = NA)
+  config <- config::get()
+  log_level <- config$rhino_log_level
+  log_file <- config$rhino_log_file
 
   logger::log_threshold(log_level)
   if (!is.na(log_file)) {

--- a/inst/templates/app_structure/config.yml
+++ b/inst/templates/app_structure/config.yml
@@ -1,0 +1,3 @@
+default:
+  rhino_log_level: !expr Sys.getenv("RHINO_LOG_LEVEL", "INFO")
+  rhino_log_file: !expr Sys.getenv("RHINO_LOG_FILE", NA)


### PR DESCRIPTION
### Changes
Closes #232.

### How to test
1. Check that `RHINO_LOG_LEVEL` and `RHINO_LOG_FILE` environment variables can be used to configure logger.
2. Try to use the `config` package in in the app: add something to `config.yml`, read it with `config$get()`, change environment with `R_CONFIG_ACTIVE`.