### PR TITLE
Max lintr errors

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -37,12 +37,20 @@ lint_r <- function() {
     lintr::lint_dir("app"),
     lintr::lint_dir(fs::path("tests", "testthat"))
   )
+  # Applying `c()` removes the `lints` class which is responsible for pretty-printing.
+  class(lints) <- "lints"
 
-  style_errors <- length(lints)
-
-  if (style_errors > max_errors) {
+  errors <- length(lints)
+  if (errors == 0) {
+    cli::cli_alert_success("No style errors found.")
+  } else {
     print(lints)
-    cli::cli_abort("Number of style errors: {style_errors}.")
+    message <- c(
+      "Found {errors} style error{?s}.",
+      i = if (max_errors > 0) "At most {max_errors} error{?s} allowed."
+    )
+    if (errors <= max_errors) cli::cli_inform(message)
+    else cli::cli_abort(message, call = NULL)
   }
 }
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -22,20 +22,17 @@ test_r <- function() {
 #'
 #' The linter rules can be adjusted in the `.lintr` file.
 #'
-#' @param accepted_errors Number of accepted style errors.
+#' You can set the maximum number of accepted style errors
+#' with the `legacy_max_lint_r_errors` option in `rhino.yml`.
+#' This can be useful when inheriting legacy code with multiple styling issues.
+#'
 #' @return None. This function is called for side effects.
 #'
-#' @examples
-#' if (interactive()) {
-#'   # Lint all R sources in the `app` and `tests/testthat` directories.
-#'   lint_r()
-#'
-#'   # Accept up to 10 errors:
-#'   lint_r(accepted_errors = 10)
-#' }
-#'
 #' @export
-lint_r <- function(accepted_errors = 0) {
+lint_r <- function() {
+  max_errors <- read_config()$legacy_max_lint_r_errors
+  if (is.null(max_errors)) max_errors <- 0
+
   lints <- c(
     lintr::lint_dir("app"),
     lintr::lint_dir(fs::path("tests", "testthat"))
@@ -43,7 +40,7 @@ lint_r <- function(accepted_errors = 0) {
 
   style_errors <- length(lints)
 
-  if (style_errors > accepted_errors) {
+  if (style_errors > max_errors) {
     print(lints)
     cli::cli_abort("Number of style errors: {style_errors}.")
   }

--- a/R/tools.R
+++ b/R/tools.R
@@ -15,6 +15,18 @@ test_r <- function() {
   testthat::test_dir(fs::path("tests", "testthat"))
 }
 
+lint_dir <- function(path) {
+  if (interactive()) {
+    message(cli::format_inline("Linting {.file {path}}"), appendLF = FALSE)
+  }
+  lints <- lintr::lint_dir(path)
+  # Return lints with full relative paths, e.g. `app/main.R` instead of just `main.R`.
+  for (i in seq_along(lints)) {
+    lints[[i]]$filename <- fs::path(path, lints[[i]]$filename)
+  }
+  lints
+}
+
 #' Lint R
 #'
 #' Uses the `{lintr}` package to check all R sources in the `app` and `tests/testthat` directories
@@ -34,8 +46,8 @@ lint_r <- function() {
   if (is.null(max_errors)) max_errors <- 0
 
   lints <- c(
-    lintr::lint_dir("app"),
-    lintr::lint_dir(fs::path("tests", "testthat"))
+    lint_dir("app"),
+    lint_dir(fs::path("tests", "testthat"))
   )
   # Applying `c()` removes the `lints` class which is responsible for pretty-printing.
   class(lints) <- "lints"

--- a/man/lint_r.Rd
+++ b/man/lint_r.Rd
@@ -4,10 +4,7 @@
 \alias{lint_r}
 \title{Lint R}
 \usage{
-lint_r(accepted_errors = 0)
-}
-\arguments{
-\item{accepted_errors}{Number of accepted style errors.}
+lint_r()
 }
 \value{
 None. This function is called for side effects.
@@ -18,14 +15,8 @@ for style errors.
 }
 \details{
 The linter rules can be adjusted in the \code{.lintr} file.
-}
-\examples{
-if (interactive()) {
-  # Lint all R sources in the `app` and `tests/testthat` directories.
-  lint_r()
 
-  # Accept up to 10 errors:
-  lint_r(accepted_errors = 10)
-}
-
+You can set the maximum number of accepted style errors
+with the \code{legacy_max_lint_r_errors} option in \code{rhino.yml}.
+This can be useful when inheriting legacy code with multiple styling issues.
 }

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,8 +1,8 @@
-test_that("validate_config() checks field value", {
+test_that("validate_config() checks option fields", {
   def <- list(
     list(
       name = "field",
-      options = c("apples", "bananas"),
+      validator = option_validator("apples", "bananas"),
       required = FALSE
     )
   )
@@ -12,11 +12,25 @@ test_that("validate_config() checks field value", {
   expect_error(validate_config(def, list(field = "cherries")))
 })
 
+test_that("validate_config() checks integer fields", {
+  def <- list(
+    list(
+      name = "field",
+      validator = positive_integer_validator,
+      required = FALSE
+    )
+  )
+  expect_silent(validate_config(def, list()))
+  expect_silent(validate_config(def, list(field = 1L)))
+  expect_error(validate_config(def, list(field = 1.)))
+  expect_error(validate_config(def, list(field = "1")))
+})
+
 test_that("validate_config() checks for required fields", {
   def <- list(
     list(
       name = "field",
-      options = c("apples", "bananas"),
+      options = positive_integer_validator,
       required = TRUE
     )
   )


### PR DESCRIPTION
### Changes
Closes #156:
1. Add support for integer fields to `validate_config()` and update `test-config.R`.
2. Add optional `legacy_max_lint_r_errors` field to `rhino.yml` and use it in `lint_r()`.
3. Improve `lint_r()` messages:
    1. Show which directories are being linted.
    2. Use full relative paths when printing lints.
    3. Display number of errors found and max allowed.

### How to test
Play around with `lint_r()` and the  `legacy_max_lint_r_errors` option in `rhino.yml`.