### PR TITLE
Read module addin from file

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -1,20 +1,8 @@
-create_module <- function() {
-  rstudioapi::insertText(glue::trim("
-    box::use(
-      shiny[moduleServer, NS]
-    )
+read_addin <- function(...) {
+  path <- fs::path_package("rhino", "rstudio", "addins", ...)
+  readChar(path, file.info(path)$size)
+}
 
-    #' @export
-    ui <- function(id) {
-      ns <- NS(id)
-
-    }
-
-    #' @export
-    server <- function(id) {
-      moduleServer(id, function(input, output, session) {
-
-      })
-  }"
-  ))
+addin_module <- function() {
+  rstudioapi::insertText(read_addin("module.R"))
 }

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,4 +1,4 @@
 Name: Rhino module
 Description: Inserts Rhino module at your cursor position.
-Binding: create_module
+Binding: addin_module
 Interactive: false

--- a/inst/rstudio/addins/module.R
+++ b/inst/rstudio/addins/module.R
@@ -1,0 +1,16 @@
+box::use(
+  shiny[moduleServer, NS]
+)
+
+#' @export
+ui <- function(id) {
+  ns <- NS(id)
+
+}
+
+#' @export
+server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+
+  })
+}


### PR DESCRIPTION
### Changes
Closes #212.

Read the module addin from a file. Resolves two issues:
1. Invalid indentation of the addin (the last line in the string literal was indented one level too shallow).
2. `devtools::document()` will no longer try to add the function to exports (it erroneously does so as it detects the `#' @export` string).

### How to test
Install the package and try to use the "Rhino module" addin in RStudio.