### PR TITLE
Remove trailing blank lines from all examples

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -87,7 +87,6 @@ with_head_tags <- function(ui) {
 #'   # Your `app.R` should contain nothing but this single call:
 #'   rhino::app()
 #' }
-#'
 #' @export
 app <- function() {
   configure_logger()

--- a/R/data.R
+++ b/R/data.R
@@ -1,6 +1,6 @@
 #' Population of rhinos
 #'
-#' A dataset containing population of 5 species of rhinos
+#' A dataset containing population of 5 species of rhinos.
 #'
 #' @format A data frame with 58 rows and 3 variables:
 #' \describe{

--- a/R/rhino.R
+++ b/R/rhino.R
@@ -92,7 +92,6 @@ check_system_dependency <- function(
 #'   # Print diagnostic information.
 #'   diagnostics()
 #' }
-#'
 #' @export
 diagnostics <- function() {
   writeLines(c(

--- a/R/tools.R
+++ b/R/tools.R
@@ -9,7 +9,6 @@
 #'   # Run all unit tests in the `tests/testthat` directory.
 #'   test_r()
 #' }
-#'
 #' @export
 test_r <- function() {
   testthat::test_dir(fs::path("tests", "testthat"))
@@ -90,7 +89,6 @@ rhino_style <- function() {
 #'   # Format all files in a directory.
 #'   format_r("app/view")
 #' }
-#'
 #' @export
 format_r <- function(paths) {
   for (path in paths) {
@@ -138,7 +136,6 @@ format_r <- function(paths) {
 #'   # Build the `app/js/index.js` file into `app/static/js/app.min.js`.
 #'   build_js()
 #' }
-#'
 #' @export
 build_js <- function(watch = FALSE) {
   if (watch) yarn("build-js", "--watch", status_ok = 2)
@@ -174,7 +171,6 @@ build_js <- function(watch = FALSE) {
 #'   # Lint the JavaScript sources in the `app/js` directory.
 #'   lint_js()
 #' }
-#'
 #' @export
 # nolint end
 lint_js <- function(fix = FALSE) {
@@ -205,7 +201,6 @@ lint_js <- function(fix = FALSE) {
 #'   # Build the `app/styles/main.scss` file into `app/static/css/app.min.css`.
 #'   build_sass()
 #' }
-#'
 #' @export
 build_sass <- function(watch = FALSE) {
   config <- read_config()$sass
@@ -255,7 +250,6 @@ build_sass_r <- function() {
 #'   # Lint the Sass sources in the `app/styles` directory.
 #'   lint_sass()
 #' }
-#'
 #' @export
 lint_sass <- function(fix = FALSE) {
   yarn("lint-sass", if (fix) "--fix")
@@ -275,7 +269,6 @@ lint_sass <- function(fix = FALSE) {
 #'   # Run the end-to-end tests in the `tests/cypress` directory.
 #'   test_e2e()
 #' }
-#'
 #' @export
 test_e2e <- function(interactive = FALSE) {
   command <- ifelse(isTRUE(interactive), "test-e2e-interactive", "test-e2e")

--- a/man/app.Rd
+++ b/man/app.Rd
@@ -54,5 +54,4 @@ into a \href{https://shiny.rstudio.com/articles/modules.html}{Shiny module}
   # Your `app.R` should contain nothing but this single call:
   rhino::app()
 }
-
 }

--- a/man/build_js.Rd
+++ b/man/build_js.Rd
@@ -39,5 +39,4 @@ if (interactive()) {
   # Build the `app/js/index.js` file into `app/static/js/app.min.js`.
   build_js()
 }
-
 }

--- a/man/build_sass.Rd
+++ b/man/build_sass.Rd
@@ -35,5 +35,4 @@ if (interactive()) {
   # Build the `app/styles/main.scss` file into `app/static/css/app.min.css`.
   build_sass()
 }
-
 }

--- a/man/diagnostics.Rd
+++ b/man/diagnostics.Rd
@@ -17,5 +17,4 @@ if (interactive()) {
   # Print diagnostic information.
   diagnostics()
 }
-
 }

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -27,5 +27,4 @@ if (interactive()) {
   # Format all files in a directory.
   format_r("app/view")
 }
-
 }

--- a/man/lint_js.Rd
+++ b/man/lint_js.Rd
@@ -36,5 +36,4 @@ if (interactive()) {
   # Lint the JavaScript sources in the `app/js` directory.
   lint_js()
 }
-
 }

--- a/man/lint_sass.Rd
+++ b/man/lint_sass.Rd
@@ -21,5 +21,4 @@ if (interactive()) {
   # Lint the Sass sources in the `app/styles` directory.
   lint_sass()
 }
-
 }

--- a/man/rhinos.Rd
+++ b/man/rhinos.Rd
@@ -19,6 +19,6 @@ A data frame with 58 rows and 3 variables:
 rhinos
 }
 \description{
-A dataset containing population of 5 species of rhinos
+A dataset containing population of 5 species of rhinos.
 }
 \keyword{datasets}

--- a/man/test_e2e.Rd
+++ b/man/test_e2e.Rd
@@ -22,5 +22,4 @@ if (interactive()) {
   # Run the end-to-end tests in the `tests/cypress` directory.
   test_e2e()
 }
-
 }

--- a/man/test_r.Rd
+++ b/man/test_r.Rd
@@ -17,5 +17,4 @@ if (interactive()) {
   # Run all unit tests in the `tests/testthat` directory.
   test_r()
 }
-
 }


### PR DESCRIPTION
### Changes
Remove trailing blank lines from all examples - they were actually visible in our `pkgdown` page.

### How to test
Run `pkgdown::build_reference()` and review function examples.