### PR TITLE
fix: make configure_logger() work with missing config fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
   yaml
 Suggests:
   knitr,
+  mockery,
   rmarkdown
 LazyData: true
 Config/testthat/edition: 3

--- a/R/app.R
+++ b/R/app.R
@@ -3,13 +3,22 @@ configure_logger <- function() {
   log_level <- config$rhino_log_level
   log_file <- config$rhino_log_file
 
-  logger::log_threshold(log_level)
-  if (!is.na(log_file)) {
-    # Use an absolute path to avoid the effects of changing the working directory when the app runs.
-    if (!fs::is_absolute_path(log_file)) {
-      log_file <- fs::path_wd(log_file)
+  if (!is.null(log_level)) {
+    logger::log_threshold(log_level)
+  } else {
+    cli::cli_alert_warning("Skipping log level configuration, 'rhino_log_level' field not found in config.")
+  }
+
+  if (!is.null(log_file)) {
+    if (!is.na(log_file)) {
+      # Use an absolute path to avoid the effects of changing the working directory when the app runs.
+      if (!fs::is_absolute_path(log_file)) {
+        log_file <- fs::path_wd(log_file)
+      }
+      logger::log_appender(logger::appender_file(log_file))
     }
-    logger::log_appender(logger::appender_file(log_file))
+  } else {
+    cli::cli_alert_warning("Skipping log file configuration, 'rhino_log_file' field not found in config.")
   }
 }
 

--- a/R/app.R
+++ b/R/app.R
@@ -6,19 +6,24 @@ configure_logger <- function() {
   if (!is.null(log_level)) {
     logger::log_threshold(log_level)
   } else {
-    cli::cli_alert_warning("Skipping log level configuration, 'rhino_log_level' field not found in config.")
+    cli::cli_alert_warning(
+      "Skipping log level configuration, 'rhino_log_level' field not found in config."
+    )
   }
 
   if (!is.null(log_file)) {
     if (!is.na(log_file)) {
-      # Use an absolute path to avoid the effects of changing the working directory when the app runs.
+      # Use an absolute path to avoid the effects of changing the working directory when the app
+      # runs.
       if (!fs::is_absolute_path(log_file)) {
         log_file <- fs::path_wd(log_file)
       }
       logger::log_appender(logger::appender_file(log_file))
     }
   } else {
-    cli::cli_alert_warning("Skipping log file configuration, 'rhino_log_file' field not found in config.")
+    cli::cli_alert_warning(
+      "Skipping log file configuration, 'rhino_log_file' field not found in config."
+    )
   }
 }
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -1,0 +1,13 @@
+test_that("configure_logger() works with missing config fields", {
+  mockery::stub(configure_logger, "config::get", list())
+  expect_message(configure_logger())
+
+  mockery::stub(configure_logger, "config::get", list(rhino_log_level = "INFO"))
+  expect_message(configure_logger())
+
+  mockery::stub(configure_logger, "config::get", list(rhino_log_file = "my.log"))
+  expect_message(configure_logger())
+
+  mockery::stub(configure_logger, "config::get", list(rhino_log_level = "INFO", rhino_log_file = "my.log"))
+  expect_silent(configure_logger())
+})

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -8,6 +8,10 @@ test_that("configure_logger() works with missing config fields", {
   mockery::stub(configure_logger, "config::get", list(rhino_log_file = "my.log"))
   expect_message(configure_logger())
 
-  mockery::stub(configure_logger, "config::get", list(rhino_log_level = "INFO", rhino_log_file = "my.log"))
+  mockery::stub(
+    configure_logger,
+    "config::get",
+    list(rhino_log_level = "INFO", rhino_log_file = "my.log")
+  )
   expect_silent(configure_logger())
 })


### PR DESCRIPTION
### Changes
Closes #245 

### How to test
1. Create a new Rhino app
1. Delete or comment out a field in `config.yml`
1. Try running the app