### PR TITLE
Correct tutorial vignettes' chart example

### DIFF
--- a/vignettes/tutorial/create-your-first-rhino-app.Rmd
+++ b/vignettes/tutorial/create-your-first-rhino-app.Rmd
@@ -165,7 +165,7 @@ To do that, add another `box::use` section in your `app/main.R` file:
 # app/main.R
 
 box::use(
-  app/view/chart
+  ./view/chart
 )
 
 ...
@@ -182,7 +182,7 @@ box::use(
 )
 
 box::use(
-  app/view/chart
+  ./view/chart
 )
 
 #' @export


### PR DESCRIPTION
Incorrect path `app/view/chart` should be `./view/chart` relative to the `app` directory.

### Changes

In the main [tutorial vignette](https://github.com/Appsilon/rhino/blob/develop/vignettes/tutorial/create-your-first-rhino-app.Rmd) I changed the example code when importing `app/view/chart` via `box::use` to be relative to the app directory: `./view/chart`. 

If run as-is receive error message: 
```
"Error in box::use(app/main): unable to load module "app/view/chart"; not found  ..."
```

### How to test

- Create new rhino app: `rhino::init(".")`
- Add chart module: `fs::file_create("app/view/chart.R")` and add the module ui and server code from the vignette.
- In `app/main.R` add the `box::use(app/view/chart)` and adjusted ui/server functions.
- Attempt to run the app, will receive error message.
- Change `box::use(app/view/chart)` to `box::use(./view/chart)` and re-run app and it should work now.
