### PR TITLE
docs: Add url to pkgdown configuration.

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -6,6 +6,8 @@ template:
   params:
     ganalytics: G-DL2H66RTY1
 
+url: https://appsilon.github.io/rhino/
+
 navbar:
   structure:
     left: [tutorial, explanation, how-to-guides, reference]


### PR DESCRIPTION
### Changes
Closes #258 

### How to test
Build page with `pkgdown::build_site()` and run it using a server (e.g. VSCode Live Server extension).