### PR TITLE
Describe how main branch is used in CONTRIBUTING guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,13 +16,12 @@ Pull requests to Rhino are welcome!
 
 ## Development Process
 
-1. We follow [Scrum](https://scrumguides.org/).
-2. All changes are introduced in pull requests to the `main` branch,
+1. All changes are introduced in pull requests to the `main` branch,
 which must be always kept in a "potentially shippable" state.
-3. Pull requests must be peer-reviewed.
+2. Pull requests must be peer-reviewed.
 The reviewer inspects the code, tests the changes
 and checks them against the [DoD](#definition-of-done) before approving.
-4. We follow the [Semantic Versioning](https://semver.org/) scheme.
+3. We follow the [Semantic Versioning](https://semver.org/) scheme.
 Starting with `1.0.0`, all versions should be released to CRAN.
 
 ## Definition of Done

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing Guidelines
+
 This document contains guidelines specific to Rhino. [Appsilon's general contributing
 guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md) still apply.
 
@@ -14,18 +15,18 @@ Pull requests to Rhino are welcome!
 
 
 ## Development Process
-1. We follow [Scrum](https://scrumguides.org/).
-2. All changes are introduced in pull requests, which must be peer-reviewed. The reviewer inspects
-   the code, tests the changes and checks them against the [DoD](#definition-of-done) before
-   approving.
-3. The `develop` branch is the base for our regular work. It is set as the "default" branch on
-   GitHub so that PRs automatically target it and `closes` keyword works in issue descriptions.
-4. The `main` branch is used for releases. We regularly merge `develop` into `main`, increment the
-   version number and tag a new release on GitHub.
-5. We follow the [Semantic Versioning](https://semver.org/) scheme.
 
+1. We follow [Scrum](https://scrumguides.org/).
+2. All changes are introduced in pull requests to the `main` branch,
+which must be always kept in a "potentially shippable" state.
+3. Pull requests must be peer-reviewed.
+The reviewer inspects the code, tests the changes
+and checks them against the [DoD](#definition-of-done) before approving.
+4. We follow the [Semantic Versioning](https://semver.org/) scheme.
+Starting with `1.0.0`, all versions should be released to CRAN.
 
 ## Definition of Done
+
 1. The PR has at least 1 approval and 0 change requests.
 2. The CI passes (`R CMD check`, linter, unit tests).
 3. The change is thoroughly documented.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/rhino)](https://cran.r-project.org/package=rhino)
 [![R build status](https://github.com/Appsilon/rhino/workflows/R-CMD-check/badge.svg)](https://github.com/Appsilon/rhino/actions)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![License: LGPL-3.0](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)][LGPL-3.0 license]
 <!-- badges: end -->
 


### PR DESCRIPTION
### Changes
Closes #163:
1. Update the docs according to our decision to only use the `main` branch.
2. Remove the "experimental" badge from `README.md`.

Once this PR is merged I will:
1. Delete the main branch and its protection rule.
2. Rename develop to main.