### PR TITLE
Run apt-get update in CI

### DIFF
--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Setup system dependencies
         run: >
-          sudo apt-get install --yes
+          sudo apt-get update && sudo apt-get install --yes
           libcurl4-openssl-dev
 
       - name: Restore renv from cache


### PR DESCRIPTION
### Changes
Run `apt-get update` in CI before installing system dependencies. I have just encountered a situation in a commercial project, where the CI was failing on this step and this change resolved the problem.

### How to test
See the [CI results](https://github.com/Appsilon/rhino/actions/runs/2345163832) on [`test-ci`](https://github.com/Appsilon/rhino/tree/test-ci) branch, which contains a freshly initialized Rhino app (using the package version from this PR).