### PR TITLE
Improve stylelint config to accept Sass at-rules

### DIFF
--- a/inst/templates/node/dot.stylelintrc.json
+++ b/inst/templates/node/dot.stylelintrc.json
@@ -1,9 +1,9 @@
 {
   "extends": "stylelint-config-standard",
-  "plugins": [
-    "stylelint-scss"
-  ],
+  "plugins": ["stylelint-scss"],
   "rules": {
-    "no-empty-source": null
+    "at-rule-no-unknown": null,
+    "no-empty-source": null,
+    "scss/at-rule-no-unknown": true
   }
 }


### PR DESCRIPTION
### Changes
Closes #285.

### How to test
Initialize a fresh project and add the following code to `app/styles/main.scss`:
```scss
@mixin shadow {
  box-shadow:
    0 4px 8px 0 rgba(0, 0, 0, 0.2),
    0 6px 20px 0 rgba(0, 0, 0, 0.2);
}

.card {
  @include shadow;
}
```

Try to run `rhino::lint_sass()`. There should be no errors reported.