### PR TITLE
Always purge box cache in rhino::app()

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -1,3 +1,9 @@
+# Make it possible to reload the app without restarting the R session.
+purge_box_cache <- function() {
+  loaded_mods <- loadNamespace("box")$loaded_mods
+  rm(list = ls(loaded_mods), envir = loaded_mods)
+}
+
 configure_logger <- function() {
   config <- config::get()
   log_level <- config$rhino_log_level
@@ -28,14 +34,9 @@ configure_logger <- function() {
 }
 
 load_main_module <- function() {
-  # Purge the box module cache, so the app can be reloaded without restarting the R session.
-  loaded_mods <- loadNamespace("box")$loaded_mods
-  rm(list = ls(loaded_mods), envir = loaded_mods)
-
-  # Silence "no visible binding" notes on R CMD check.
-  r <- NULL
+  # Silence "no visible binding" notes raised by `box::use()` on R CMD check.
+  app <- NULL
   main <- NULL
-
   box::use(app/main)
   main
 }
@@ -103,6 +104,7 @@ with_head_tags <- function(ui) {
 #' }
 #' @export
 app <- function() {
+  purge_box_cache()
   configure_logger()
   shiny::addResourcePath("static", fs::path_wd("app", "static"))
 


### PR DESCRIPTION
### Changes
Closes #282: `rhino::app()` will now purge box cache the very first thing, regardless of `legacy_entrypoint` setting.

### How to test
Try reloading the app without restarting the R session with all 4 `legacy_entrypoint` settings. Box cache should be purged and modules reloaded at all times.

You still need to ensure that `rhino::app()` re-executes: stop the application and restart it (in the same session) using "Run app" button or `shiny::runApp()`.