### PR TITLE
Work around server reloading issues

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -46,11 +46,11 @@ as_top_level <- function(shiny_module) {
   # https://adv-r.hadley.nz/function-factories.html?q=force#forcing-evaluation
   force(shiny_module)
 
-  list(
-    # Wrap the UI in a function to support Shiny bookmarking.
-    ui = function(request) shiny_module$ui("app"),
-    server = function(input, output) shiny_module$server("app")
-  )
+  # The actual function must be sourced with `keep.source = TRUE` for reloading to work:
+  # https://github.com/Appsilon/rhino/issues/157
+  wrap <- source(fs::path_package("rhino", "as_top_level.R"), keep.source = TRUE)$value
+
+  wrap(shiny_module)
 }
 
 attach_head_tags <- function(ui) {

--- a/inst/as_top_level.R
+++ b/inst/as_top_level.R
@@ -1,0 +1,10 @@
+function(shiny_module) {
+  list(
+    # Wrap the UI in a function to support Shiny bookmarking.
+    ui = function(request) shiny_module$ui("app"),
+    # The curly braces below are essential: https://github.com/Appsilon/rhino/issues/157
+    server = function(input, output) {
+      shiny_module$server("app")
+    }
+  )
+}

--- a/inst/as_top_level.R
+++ b/inst/as_top_level.R
@@ -1,3 +1,5 @@
+# This function is defined in the `inst` directory, as it must be sourced with `keep.source = TRUE`
+# for reloading to work: https://github.com/Appsilon/rhino/issues/157
 function(shiny_module) {
   list(
     # Wrap the UI in a function to support Shiny bookmarking.


### PR DESCRIPTION
### Changes
Closes #157. This was a really tricky bug and I still don't fully understand why it happens. My comments in the issue detail the investigation; [this one](https://github.com/Appsilon/rhino/issues/157#issuecomment-1169925583) in particular provides a minimal example which explains the changes in this PR.

In short, it seems that two things must be true about the `server` passed to `shinyApp()` for reloading to work properly:
1. It must be defined using curly braces (`function(input, output) { module_server("app") }` and not `function(input, output) module_server("app")`).
2. It must be evaluated (defined, created) in a file sourced with `keep.source = TRUE`.

### How to test
Initialize a fresh project and run it with `shiny::runApp()`. Add some changes in the server of `main.R`, e.g. change the "Hello!" string. It should be sufficient to `touch app.R` (update its timestamp) and refresh the page in the browser to see the changes.