### PR TITLE
Change maintainer to an alias

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,11 @@ Title: A Framework for Enterprise Shiny Applications
 Version: 1.0.0
 Authors@R:
   c(
-    person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),
+    person("Kamil", "Zyla", role = "aut", email = "kamil@appsilon.com"),
     person("Jakub", "Nowicki", role = "aut", email = "kuba@appsilon.com"),
     person("Tymoteusz", "Makowski", role = "aut", email = "tymoteusz@appsilon.com"),
     person("Marek", "Rogala", role = "aut", email = "marek@appsilon.com"),
-    person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
+    person("Appsilon Sp. z o.o.", role = c("cph", "cre"), email = "opensource@appsilon.com")
   )
 Description: A framework that supports creating and extending enterprise Shiny applications using best practices.
 URL: https://appsilon.github.io/rhino/, https://github.com/Appsilon/rhino


### PR DESCRIPTION
I think it's worth trying to change the maintainer email to an alias in the release next week :slightly_smiling_face: Hopefully CRAN folks will be fine with that and if not - it's not a big deal and we should have enough time to revert this and resubmit.