### PR TITLE
Change maintainer back to Kamil

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,11 @@ Title: A Framework for Enterprise Shiny Applications
 Version: 1.1.0
 Authors@R:
   c(
-    person("Kamil", "Zyla", role = "aut", email = "kamil@appsilon.com"),
+    person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),
     person("Jakub", "Nowicki", role = "aut", email = "kuba@appsilon.com"),
     person("Tymoteusz", "Makowski", role = "aut", email = "tymoteusz@appsilon.com"),
     person("Marek", "Rogala", role = "aut", email = "marek@appsilon.com"),
-    person("Appsilon Sp. z o.o.", role = c("cph", "cre"), email = "opensource@appsilon.com")
+    person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
   )
 Description: A framework that supports creating and extending enterprise Shiny applications using best practices.
 URL: https://appsilon.github.io/rhino/, https://github.com/Appsilon/rhino


### PR DESCRIPTION
### Changes
We made an attempt to change the maintainer to an alias (it was previously accepted for some of our packages), but CRAN folks didn't like it:

> Thanks, we see:
> 
>   New maintainer:
>      Appsilon Sp. z o.o. <[opensource@appsilon.com](mailto:opensource@appsilon.com)>
> 
> But this is not a single designated maintainer (a person) as required by
> the CRAN policies.
> We cannot accept a non person as maintiner.
> 
> Please fix and resubmit.

The PR reverts the change.