### PR TITLE
Add upcoming events section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 [![License: LGPL-3.0](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](https://opensource.org/licenses/LGPL-3.0)
 <!-- badges: end -->
 
+## Upcoming events
+
+Would you like to learn about Rhino hands-on? Join our events!
+
+* August 22, 2022: *Enterprise-grade Shiny App Development with {rhino}*
+led by [Jakub Nowicki](https://www.linkedin.com/in/jakub-nowicki/).
+The workshop will be held during the [R/Medicine](https://events.linuxfoundation.org/r-medicine/) conference.
+* September 6, 2022: *Creating Shiny Apps with Rhino*
+led by [Kamil Żyła](https://www.linkedin.com/in/kamil-zyla/).
+It will be a rerun of the [workshop](https://www.youtube.com/watch?v=8H_ZHUy8Yj4) which was held shortly after the initial Rhino release.
+
+Details (time, how to join) to be announced - come back soon!
 
 ## Why Rhino?
 Rhino allows you to create Shiny apps **The Appsilon Way**  - like a fullstack software engineer. Apply best software engineering practices, modularize your code, test it well, make UI beautiful, and think about user adoption from the very beginning. Rhino is an opinionated framework with a focus on software engineering practices and development tools.


### PR DESCRIPTION
### Changes
As discussed during Rhino bi-weekly, add a short info about upcoming workshops to our README. I don't have the details yet (e.g. time and how to join), so we'll need to update the info later.
