### PR TITLE
Update info on upcoming events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 Would you like to learn about Rhino hands-on? Join our events!
 
-* August 22, 2022: *Enterprise-grade Shiny App Development with {rhino}*
-led by [Jakub Nowicki](https://www.linkedin.com/in/jakub-nowicki/).
-The workshop will be held during the [R/Medicine](https://events.linuxfoundation.org/r-medicine/) conference.
-* September 6, 2022 at 2 PM (GMT+2):
-[*Creating Shiny Apps with Rhino*](https://hopin.com/events/shinygathering-1-rhino)
-led by [Kamil Żyła](https://www.linkedin.com/in/kamil-zyla/).
-It will be a rerun of the [workshop](https://www.youtube.com/watch?v=8H_ZHUy8Yj4) which was held shortly after the initial Rhino release.
+* August 23, 2022 at 11:00 AM (UTC-4): *Enterprise-grade Shiny App Development with {rhino}*.
+The workshop will be led by [Jakub Nowicki](https://www.linkedin.com/in/jakub-nowicki/)
+during the [R/Medicine](https://events.linuxfoundation.org/r-medicine/) conference.
+* September 7, 2022 at 11:30 AM (UTC+1):
+*Introducing Rhino: Shiny application framework for enterprise*.
+The talk will be given by [Jakub Nowicki](https://www.linkedin.com/in/jakub-nowicki/)
+during the [EARL](https://www.ascent.io/earl) conference.
 
 ## Why Rhino?
 Rhino allows you to create Shiny apps **The Appsilon Way**  - like a fullstack software engineer. Apply best software engineering practices, modularize your code, test it well, make UI beautiful, and think about user adoption from the very beginning. Rhino is an opinionated framework with a focus on software engineering practices and development tools.


### PR DESCRIPTION
### Changes
1. Update info about the R/Medicine workshop.
2. Remove the info about my workshop. After some internal discussions we figured that it would be better to hold something special instead of just re-running a previous workshop. We'll need more time to prepare though; it's OK to cancel as nobody has signed up yet.
3. Add info about EARL talk.
