### PR TITLE
Upgrade roxygen2 to 7.2.1 and regenerate documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.0
+Version: 1.1.1
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),
@@ -15,7 +15,7 @@ BugReports: https://github.com/Appsilon/rhino/issues
 License: LGPL-3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Depends:
   R (>= 2.10)
 Imports:

--- a/man/build_js.Rd
+++ b/man/build_js.Rd
@@ -22,16 +22,24 @@ Requires Node.js and the \code{yarn} command to be available on the system.
 }
 \details{
 Functions/objects defined in the global scope do not automatically become \code{window} properties,
-so the following JS code:\if{html}{\out{<div class="sourceCode js">}}\preformatted{function sayHello() \{ alert('Hello!'); \}
+so the following JS code:
+
+\if{html}{\out{<div class="sourceCode js">}}\preformatted{function sayHello() \{ alert('Hello!'); \}
 }\if{html}{\out{</div>}}
 
-won't work as expected if used in R like this:\if{html}{\out{<div class="sourceCode r">}}\preformatted{tags$button("Hello!", onclick = 'sayHello()');
+won't work as expected if used in R like this:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tags$button("Hello!", onclick = 'sayHello()');
 }\if{html}{\out{</div>}}
 
-Instead you should explicitly export functions:\if{html}{\out{<div class="sourceCode js">}}\preformatted{export function sayHello() \{ alert('Hello!'); \}
+Instead you should explicitly export functions:
+
+\if{html}{\out{<div class="sourceCode js">}}\preformatted{export function sayHello() \{ alert('Hello!'); \}
 }\if{html}{\out{</div>}}
 
-and access them via the global \code{App} object:\if{html}{\out{<div class="sourceCode r">}}\preformatted{tags$button("Hello!", onclick = "App.sayHello()")
+and access them via the global \code{App} object:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tags$button("Hello!", onclick = "App.sayHello()")
 }\if{html}{\out{</div>}}
 }
 \examples{

--- a/man/lint_js.Rd
+++ b/man/lint_js.Rd
@@ -25,7 +25,9 @@ To access it without raising linter errors, add \verb{/* global L */} comment in
 You don't need to define \code{Shiny} and \code{$} as these global variables are defined by default.
 
 If you find a particular ESLint error inapplicable to your code,
-you can disable a specific rule for the next line of code with a comment like:\if{html}{\out{<div class="sourceCode js">}}\preformatted{// eslint-disable-next-line no-restricted-syntax
+you can disable a specific rule for the next line of code with a comment like:
+
+\if{html}{\out{<div class="sourceCode js">}}\preformatted{// eslint-disable-next-line no-restricted-syntax
 }\if{html}{\out{</div>}}
 
 See the \href{https://eslint.org/docs/user-guide/configuring/rules#using-configuration-comments-1}{ESLint documentation}


### PR DESCRIPTION
### Mail from CRAN

> Dear maintainer,
> 
> Please see the problems shown on
> <https://cran.r-project.org/web/checks/check_results_rhino.html>.
> 
> In particular, please see the "Found the following HTML validation
> problems" NOTEs in the "HTML version of manual" check for at least some
> of the r-devel checks results. 
> 
> R 4.2.0 switched to use HTML5 for documentation pages.  Now validation
> using HTML Tidy finds problems in the HTML generated from your Rd
> files. 
> 
> To fix, in most cases it suffices to re-generate the Rd files using the
> current CRAN version of roxygen2.  To check whether this already fixes
> things, or whether additional changes you made fixed the problems (e.g.,
> if the problem is from yourself directly generating HTML output), you
> can grab HTML Tidy version 5.8.0 binaries from
> <https://binaries.html-tidy.org/> and, with FOO.Rd an Rd file for which
> problems were found, run
> 
>   R CMD Rdconv -t html /path/to/FOO.Rd -o FOO.html
>   tidy -qe --drop-empty-elements no FOO.html
> 
> (Alternatively, you can use R CMD check --as-cran using a current
> version of R-devel.)
> 
> Can you please fix as necessary?
> 
> Please correct before 2022-09-09 to safely retain your package on CRAN.
> 
> Best,
> -k

### Changes
Upgrade roxygen2 to 7.2.1 and regenerate documentation. Bump package version to 1.1.1.