### PR TITLE
Feat: Adds Path argument to `lint_r()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1
+Version: 1.1.1.9999
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9999
+Version: 1.1.1.9000
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rhino 1.1.1.9999
+# rhino (development version)
 
 * Added a `NEWS.md` file to track changes to the package.
-* Adds `paths` argument to `lint_r()`. `paths` defaults to `NULL` and should lint `app` and `tests/testthat` as default. `paths` should take a vector of directory or file paths and return lint error or success messages whichever is appropriate. 
+* Added a `paths` argument to `lint_r()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,4 @@
+# rhino 1.1.1.9999
+
+* Added a `NEWS.md` file to track changes to the package.
+* Adds `paths` argument to `lint_r()`. `paths` defaults to `NULL` and should lint `app` and `tests/testthat` as default. `paths` should take a vector of directory or file paths and return lint error or success messages whichever is appropriate. 

--- a/R/tools.R
+++ b/R/tools.R
@@ -15,6 +15,13 @@ test_r <- function() {
 }
 
 lint_dir <- function(path) {
+  if (!fs::dir_exists(path)) {
+    cli::cli_abort(c(
+      "Nothing to lint.",
+      "i" = "Please make sure that {.file {path}} exists."
+    ))
+  }
+
   if (interactive()) {
     message(cli::format_inline("Linting {.file {path}}"), appendLF = FALSE)
   }
@@ -27,6 +34,13 @@ lint_dir <- function(path) {
 }
 
 lint_file <- function(path) {
+  if (!fs::file_exists(path)) {
+    cli::cli_abort(c(
+      "Nothing to lint.",
+      "i" = "Please make sure that {.file {path}} exists."
+    ))
+  }
+
   if (interactive()) {
     message(cli::format_inline("Linting {.file {path}}"))
   }

--- a/R/tools.R
+++ b/R/tools.R
@@ -90,15 +90,15 @@ check_paths <- function(paths) {
 #'
 #' @export
 lint_r <- function(paths = NULL) {
+  if (is.null(paths)) {
+    paths <- c("app", "tests/testthat")
+  }
+
   paths <- check_paths(paths = paths)
 
   max_errors <- read_config()$legacy_max_lint_r_errors
 
   if (is.null(max_errors)) max_errors <- 0
-
-  if (is.null(paths)) {
-    paths <- c("app", "tests/testthat")
-  }
 
   lints <- do.call(c, lapply(paths, lint_path))
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -53,16 +53,16 @@ lint_path <- function(path) {
 check_paths <- function(paths) {
   readable <- fs::file_access(paths, mode = "read")
 
-  if (any(!readable))
+  if (any(!readable)) {
     cli::cli_abort(
       c(
         "Cannot lint an invalid path.",
-        i = "Please check that {cli::col_blue('paths')} contain only valid paths.",
+        i = "Please check that {.arg paths} contain only valid paths.",
         i = "The following path{?s} cannot be read: {.file {paths[!readable]}}."
-      )
+      ),
+      call = NULL
     )
-
-  paths
+  }
 }
 
 #' Lint R
@@ -86,7 +86,7 @@ lint_r <- function(paths = NULL) {
   if (is.null(paths)) {
     paths <- c("app", "tests/testthat")
   }
-  paths <- check_paths(paths)
+  check_paths(paths)
   max_errors <- read_config()$legacy_max_lint_r_errors
   if (is.null(max_errors)) max_errors <- 0
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -61,7 +61,7 @@ check_paths <- function(paths) {
         i = "The following path{?s} cannot be read: {.file {paths[!readable]}}."
       )
     )
-  
+
   paths
 }
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -15,13 +15,6 @@ test_r <- function() {
 }
 
 lint_dir <- function(path) {
-  if (!fs::dir_exists(path)) {
-    cli::cli_abort(c(
-      "Nothing to lint.",
-      "i" = "Please make sure that {.file {path}} exists."
-    ))
-  }
-
   if (interactive()) {
     message(cli::format_inline("Linting {.file {path}}"), appendLF = FALSE)
   }
@@ -34,13 +27,6 @@ lint_dir <- function(path) {
 }
 
 lint_file <- function(path) {
-  if (!fs::file_exists(path)) {
-    cli::cli_abort(c(
-      "Nothing to lint.",
-      "i" = "Please make sure that {.file {path}} exists."
-    ))
-  }
-
   if (interactive()) {
     message(cli::format_inline("Linting {.file {path}}"))
   }
@@ -62,6 +48,30 @@ lint_path <- function(path) {
   }
 }
 
+check_paths <- function(paths) {
+  paths_exist <- fs::file_access(paths, mode = "exists")
+
+  if (all(!paths_exist)) {
+    cli::cli_abort(
+      c(
+        "Nothing to lint.",
+        i = "Please check that {cli::col_blue('paths')} has at
+          least {cli::style_underline('ONE')} existing file or directory."
+      )
+    )
+  } else if (any(!paths_exist)) {
+    cli::cli_inform(
+      ifelse(
+        length(paths[!paths_exist]) > 1,
+        "The following paths do not exist: {.file {paths[!paths_exist]}}.",
+        "This path does not exist: {.file {paths[!paths_exist]}}."
+      )
+    )
+  }
+
+  paths[paths_exist]
+}
+
 #' Lint R
 #'
 #' Uses the `{lintr}` package to check all R sources in the `app` and `tests/testthat` directories
@@ -80,7 +90,10 @@ lint_path <- function(path) {
 #'
 #' @export
 lint_r <- function(paths = NULL) {
+  paths <- check_paths(paths = paths)
+
   max_errors <- read_config()$legacy_max_lint_r_errors
+
   if (is.null(max_errors)) max_errors <- 0
 
   if (is.null(paths)) {

--- a/R/tools.R
+++ b/R/tools.R
@@ -61,7 +61,7 @@ lint_r <- function(paths = NULL) {
 
   lints <- purrr::map(
     paths,
-    lint_path
+    ~ c(lint_path(.x))
   )
 
   lints <- purrr::reduce(lints, c)

--- a/R/tools.R
+++ b/R/tools.R
@@ -44,7 +44,7 @@ lint_path <- function(path) {
   if (fs::is_dir(path)) {
     lint_dir(path)
   } else if (fs::is_file(path)) {
-    lint_path(path)
+    lint_file(path)
   }
 }
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -30,6 +30,9 @@ lint_path <- function(path) {
   if (fs::is_dir(path)) {
     lint_dir(path)
   } else {
+    if (interactive()) {
+      message(cli::format_inline("Linting {.file {path}}"))
+    }
     lintr::lint(filename = path)
   }
 }

--- a/man/lint_r.Rd
+++ b/man/lint_r.Rd
@@ -4,7 +4,11 @@
 \alias{lint_r}
 \title{Lint R}
 \usage{
-lint_r()
+lint_r(paths = NULL)
+}
+\arguments{
+\item{paths}{a vector paths to directories or \code{.R} files; defaults to \code{NULL} and checks \code{app} and
+\code{tests/testthat} directories}
 }
 \value{
 None. This function is called for side effects.
@@ -16,7 +20,7 @@ for style errors.
 \details{
 The linter rules can be adjusted in the \code{.lintr} file.
 
-You can set the maximum number of accepted style errors
-with the \code{legacy_max_lint_r_errors} option in \code{rhino.yml}.
-This can be useful when inheriting legacy code with multiple styling issues.
+You can set the maximum number of accepted style errors with the \code{legacy_max_lint_r_errors}
+option in \code{rhino.yml}. This can be useful when inheriting legacy code with multiple styling
+issues.
 }

--- a/man/lint_r.Rd
+++ b/man/lint_r.Rd
@@ -7,8 +7,8 @@
 lint_r(paths = NULL)
 }
 \arguments{
-\item{paths}{a vector paths to directories or \code{.R} files; defaults to \code{NULL} and checks \code{app} and
-\code{tests/testthat} directories}
+\item{paths}{Character vector of directories and files to lint.
+When \code{NULL} (the default), check \code{app} and \code{tests/testthat} directories.}
 }
 \value{
 None. This function is called for side effects.
@@ -20,7 +20,7 @@ for style errors.
 \details{
 The linter rules can be adjusted in the \code{.lintr} file.
 
-You can set the maximum number of accepted style errors with the \code{legacy_max_lint_r_errors}
-option in \code{rhino.yml}. This can be useful when inheriting legacy code with multiple styling
-issues.
+You can set the maximum number of accepted style errors
+with the \code{legacy_max_lint_r_errors} option in \code{rhino.yml}.
+This can be useful when inheriting legacy code with multiple styling issues.
 }


### PR DESCRIPTION
### Changes
Closes #281

* Adds `paths` to `lint_r()`. Default is `paths = NULL` and will run the lint on `app` and `tests/testthat`.
* `paths` will take a vector of directories relative to the root directory, i.e. the `rhino` directory. `paths` can either be a directory or a `.R` file. 
* Bumps version to dev `1.1.1.9999`. I added NEWS.md` to document the change too.
* `roxygen` should be updated with new argument.

### How to test
* Install `rhino v1.1.1.9999` via `devtools::build()`.
* Test on any `rhino` app. It should also work on any directory or `.R` file.

#### Notes
* I had to create a new function `lint_path()` that will either run `rhino::::lint_dir()` if the path is a directory or `lintr::lint()` if the path is a `.R` file.  I added a message when linting a file similar to the message when linting a directory to make it easier for users to track the linting process.
* This took a while to figure out, but I used `purrr::map()` to allow for multiple paths.
* The function I mapped is `c(lint_path())` to capture the lints, but prevent it from printing the errors immediately.
* I also had to use `purrr::reduce()` with `c()` because `map` returns a list. Using `c()` still requires the setting of `lints` class.
* I wrote some tests for `lint_r()` (see ca24f1f6acf79858e84e1a7f51c9990945567c5d), but I did not include it here because there are intentional lint errors and since we are using `lintr::lint_package()` in the workflow, the tests will throw errors. We can exclude the test directory with lint errors if that is fine, but I think that needs approval since it will change the workflow. 
