### PR TITLE
Feat: Use `renv.lock` `R` Version in CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9003
+Version: 1.1.1.9004
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,4 +4,4 @@
 * Added a `paths` argument to `lint_r()`.
 * Prevent `init()` in home directory.
 * Included `build_js()` and `build_sass()` in template CI.
-* Changed CI `R_VERSION` to `renv.lock` `R_VERSION`.
+* Use R version from the lockfile in CI.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,3 +4,4 @@
 * Added a `paths` argument to `lint_r()`.
 * Prevent `init()` in home directory.
 * Included `build_js()` and `build_sass()` in template CI.
+* Changed CI `R_VERSION` to `renv.lock` `R_VERSION`.

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -7,11 +7,15 @@ jobs:
     name: Run linters and tests
     runs-on: ubuntu-20.04
     env:
-      R_VERSION: '4.1.0'
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        
+      - name: Extract R.version from renv.lock
+        run: |
+          r_version=`jq .R.Version renv.lock | xargs`
+          echo "R_VERSION=$r_version" >> $GITHUB_ENV
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v1

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -12,10 +12,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         
-      - name: Extract R.version from renv.lock
-        run: |
-          r_version=`jq .R.Version renv.lock | xargs`
-          echo "R_VERSION=$r_version" >> $GITHUB_ENV
+      - name: Extract R version from lockfile
+        run: printf 'R_VERSION=%s\n' "$(jq --raw-output .R.Version renv.lock)" >> $GITHUB_ENV
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v1


### PR DESCRIPTION
### Changes
Closes #342

* Default `R_VERSION: '4.1.0'` should be removed from `GITHUB_ENV`.
* `R.Version` from `renv.lock` should be read in a new step and assigned to `R_VERSION`
* CI should now use `R.Version` provided in `renv.lock`.

### Tests

* [R 4.1.1 without GITHUB_PAT](https://github.com/Appsilon/rhino-showcase/actions/runs/3310764031)
* [R 4.2.1 without GITHUB_PAT](https://github.com/Appsilon/rhino-showcase/actions/runs/3310837024)
* [R 4.2.1 with GITHUB_PAT](https://github.com/Appsilon/rhino-showcase/actions/runs/3310950060)
