### PR TITLE
Feat: Adds NEWS to `pkgdown` site and links to previous two releases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,3 +5,47 @@
 * Prevent `init()` in home directory.
 * Included `build_js()` and `build_sass()` in template CI.
 * Use R version from the lockfile in CI.
+
+# rhino 1.1.1
+
+## What's Changed
+* Add upcoming events section to the README by @kamilzyla in https://github.com/Appsilon/rhino/pull/311
+* Update upcoming events by @kamilzyla in https://github.com/Appsilon/rhino/pull/315
+* Update info on upcoming events by @kamilzyla in https://github.com/Appsilon/rhino/pull/316
+* Upgrade roxygen2 to 7.2.1 and regenerate documentation by @kamilzyla in https://github.com/Appsilon/rhino/pull/320
+
+# rhino 1.1.0
+
+## Highlights
+1. New guide:  "How to manage secrets and environments" (#263).
+2. Sass-specific at-rules are now recognized by `rhino::lint_sass()` (#289).
+3. Shiny bookmarking now works (#294).
+4. RStudio no longer complains about "too many files" during push-button deployment  (#299).
+5. Issues with server reloading during development resolved (#297).
+
+## What's Changed
+* docs: Add url to pkgdown configuration. by @jakubnowicki in https://github.com/Appsilon/rhino/pull/260
+* fix: make configure_logger() work with missing config fields by @TymekDev in https://github.com/Appsilon/rhino/pull/254
+* Rhino Tutorial: Minor text and css changes for app preview images by @ianemoore in https://github.com/Appsilon/rhino/pull/241
+* What is rhino edit by @ianemoore in https://github.com/Appsilon/rhino/pull/256
+* Edit app structure by @ianemoore in https://github.com/Appsilon/rhino/pull/257
+* docs: add note about native pipe operator by @TymekDev in https://github.com/Appsilon/rhino/pull/262
+* Describe how main branch is used in CONTRIBUTING guide by @kamilzyla in https://github.com/Appsilon/rhino/pull/265
+* docs: add secrets and environments how to guide by @TymekDev in https://github.com/Appsilon/rhino/pull/263
+* Indicate stub status in the article header by @kamilzyla in https://github.com/Appsilon/rhino/pull/266
+* Draft articles by @kamilzyla in https://github.com/Appsilon/rhino/pull/267
+* Configure issue templates by @kamilzyla in https://github.com/Appsilon/rhino/pull/269
+* Update the GTM container ID by @kamilzyla in https://github.com/Appsilon/rhino/pull/272
+* Run apt-get update in CI by @kamilzyla in https://github.com/Appsilon/rhino/pull/275
+* Improve stylelint config to accept Sass at-rules by @kamilzyla in https://github.com/Appsilon/rhino/pull/289
+* Explain documentation structure by @kamilzyla in https://github.com/Appsilon/rhino/pull/290
+* Always purge box cache in rhino::app() by @kamilzyla in https://github.com/Appsilon/rhino/pull/292
+* Support bookmarking by @kamilzyla in https://github.com/Appsilon/rhino/pull/294
+* Update lintr config after 3.0.0 release by @kamilzyla in https://github.com/Appsilon/rhino/pull/296
+* Simplify CI into a single workflow by @kamilzyla in https://github.com/Appsilon/rhino/pull/301
+* feat: Add a template for .rscignore file. by @jakubnowicki in https://github.com/Appsilon/rhino/pull/299
+* Wording and style improvements for tutorial by @kamilzyla in https://github.com/Appsilon/rhino/pull/273
+* Change maintainer to an alias by @kamilzyla in https://github.com/Appsilon/rhino/pull/303
+* Work around server reloading issues by @kamilzyla in https://github.com/Appsilon/rhino/pull/297
+* Bump version to 1.1.0 by @kamilzyla in https://github.com/Appsilon/rhino/pull/304
+* Change maintainer back to Kamil by @kamilzyla in https://github.com/Appsilon/rhino/pull/305

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,46 +6,19 @@
 * Included `build_js()` and `build_sass()` in template CI.
 * Use R version from the lockfile in CI.
 
-# rhino 1.1.1
+# [rhino 1.1.1](https://github.com/Appsilon/rhino/releases/tag/v1.1.1)
 
-## What's Changed
-* Add upcoming events section to the README by @kamilzyla in https://github.com/Appsilon/rhino/pull/311
-* Update upcoming events by @kamilzyla in https://github.com/Appsilon/rhino/pull/315
-* Update info on upcoming events by @kamilzyla in https://github.com/Appsilon/rhino/pull/316
-* Upgrade roxygen2 to 7.2.1 and regenerate documentation by @kamilzyla in https://github.com/Appsilon/rhino/pull/320
+Minor release to fix CRAN check failures (upgrade roxygen2 to 7.2.1 and regenerate documentation).
 
-# rhino 1.1.0
+# [rhino 1.1.0](https://github.com/Appsilon/rhino/releases/tag/v1.1.0)
 
 ## Highlights
 1. New guide:  "How to manage secrets and environments" (#263).
 2. Sass-specific at-rules are now recognized by `rhino::lint_sass()` (#289).
 3. Shiny bookmarking now works (#294).
-4. RStudio no longer complains about "too many files" during push-button deployment  (#299).
+4. RStudio no longer complains about "too many files" during push-button deployment (#299).
 5. Issues with server reloading during development resolved (#297).
 
-## What's Changed
-* docs: Add url to pkgdown configuration. by @jakubnowicki in https://github.com/Appsilon/rhino/pull/260
-* fix: make configure_logger() work with missing config fields by @TymekDev in https://github.com/Appsilon/rhino/pull/254
-* Rhino Tutorial: Minor text and css changes for app preview images by @ianemoore in https://github.com/Appsilon/rhino/pull/241
-* What is rhino edit by @ianemoore in https://github.com/Appsilon/rhino/pull/256
-* Edit app structure by @ianemoore in https://github.com/Appsilon/rhino/pull/257
-* docs: add note about native pipe operator by @TymekDev in https://github.com/Appsilon/rhino/pull/262
-* Describe how main branch is used in CONTRIBUTING guide by @kamilzyla in https://github.com/Appsilon/rhino/pull/265
-* docs: add secrets and environments how to guide by @TymekDev in https://github.com/Appsilon/rhino/pull/263
-* Indicate stub status in the article header by @kamilzyla in https://github.com/Appsilon/rhino/pull/266
-* Draft articles by @kamilzyla in https://github.com/Appsilon/rhino/pull/267
-* Configure issue templates by @kamilzyla in https://github.com/Appsilon/rhino/pull/269
-* Update the GTM container ID by @kamilzyla in https://github.com/Appsilon/rhino/pull/272
-* Run apt-get update in CI by @kamilzyla in https://github.com/Appsilon/rhino/pull/275
-* Improve stylelint config to accept Sass at-rules by @kamilzyla in https://github.com/Appsilon/rhino/pull/289
-* Explain documentation structure by @kamilzyla in https://github.com/Appsilon/rhino/pull/290
-* Always purge box cache in rhino::app() by @kamilzyla in https://github.com/Appsilon/rhino/pull/292
-* Support bookmarking by @kamilzyla in https://github.com/Appsilon/rhino/pull/294
-* Update lintr config after 3.0.0 release by @kamilzyla in https://github.com/Appsilon/rhino/pull/296
-* Simplify CI into a single workflow by @kamilzyla in https://github.com/Appsilon/rhino/pull/301
-* feat: Add a template for .rscignore file. by @jakubnowicki in https://github.com/Appsilon/rhino/pull/299
-* Wording and style improvements for tutorial by @kamilzyla in https://github.com/Appsilon/rhino/pull/273
-* Change maintainer to an alias by @kamilzyla in https://github.com/Appsilon/rhino/pull/303
-* Work around server reloading issues by @kamilzyla in https://github.com/Appsilon/rhino/pull/297
-* Bump version to 1.1.0 by @kamilzyla in https://github.com/Appsilon/rhino/pull/304
-* Change maintainer back to Kamil by @kamilzyla in https://github.com/Appsilon/rhino/pull/305
+# [rhino 1.0.0](https://github.com/Appsilon/rhino/releases/tag/v1.0.0)
+
+First stable version.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,12 +1,10 @@
 Appsilon
 Boxifying
 ESLint
-GTM
 Init
 JS
 LatinR
 LibSass
-README
 RStudio
 Renv
 Renviron
@@ -14,7 +12,6 @@ Rprofile
 Stylelint
 UI
 config
-css
 devtools
 entrypoint
 favicon
@@ -26,7 +23,6 @@ isolatable
 js
 linter
 linters
-lintr
 lockfile
 minified
 modularization
@@ -35,14 +31,11 @@ modularized
 namespaced
 npm
 overridable
-pkgdown
 preconfigured
 renv
 roxygen
-rscignore
 scalable
 shinyapps
-stylelint
 ui
 unintuitive
 usethis

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,10 +1,12 @@
 Appsilon
 Boxifying
 ESLint
+GTM
 Init
 JS
 LatinR
 LibSass
+README
 RStudio
 Renv
 Renviron
@@ -12,6 +14,7 @@ Rprofile
 Stylelint
 UI
 config
+css
 devtools
 entrypoint
 favicon
@@ -23,6 +26,7 @@ isolatable
 js
 linter
 linters
+lintr
 lockfile
 minified
 modularization
@@ -31,10 +35,14 @@ modularized
 namespaced
 npm
 overridable
+pkgdown
 preconfigured
 renv
+roxygen
+rscignore
 scalable
 shinyapps
+stylelint
 ui
 unintuitive
 usethis

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -19,7 +19,7 @@ url: https://appsilon.github.io/rhino/
 
 navbar:
   structure:
-    left: [tutorial, explanation, how-to-guides, reference]
+    left: [tutorial, explanation, how-to-guides, reference, news]
   components:
     tutorial:
       text: Tutorial
@@ -87,3 +87,10 @@ reference:
 - title: Data
   contents:
   - rhinos
+
+news:
+  releases:
+  - text: "Version 1.1.1"
+    href: https://github.com/Appsilon/rhino/releases/tag/v1.1.1
+  - text: "Version 1.1.0"
+    href: https://github.com/Appsilon/rhino/releases/tag/v1.1.0

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -87,10 +87,3 @@ reference:
 - title: Data
   contents:
   - rhinos
-
-news:
-  releases:
-  - text: "Version 1.1.1"
-    href: https://github.com/Appsilon/rhino/releases/tag/v1.1.1
-  - text: "Version 1.1.0"
-    href: https://github.com/Appsilon/rhino/releases/tag/v1.1.0


### PR DESCRIPTION
### Changes
Closes #361 

* Creates a changelog page from `NEWS.md`.
* Adds highlights from `rhino 1.1.0` and `rhino 1.1.1` releases. I took the liberty to add these to `NEWS.md` to provide more content to the page. This did require me to update `inst/WORDLIST` because of the new words that can be ignored by spellcheck.
* Provides Github links to the releases. As far as I know, we do not have a [release posts similar to `tidyverse` blog](https://www.tidyverse.org/blog/2019/09/devtools-2-2-1/). Maybe we can do this too as a part of marketing/promotion whenever we do releases.

### Output

![image](https://user-images.githubusercontent.com/110383037/198241274-b8f3ee62-5a59-47cb-b6ca-d1bea3a8cdf9.png)

Note: My output site failed to render images in the vignettes. Not sure why, but this might be ok when deployed, so please check that too.

