### PR TITLE
Explicitly require Yarn Classic

### DIFF
--- a/vignettes/how-to/use-rhino-on-windows.Rmd
+++ b/vignettes/how-to/use-rhino-on-windows.Rmd
@@ -15,5 +15,5 @@ Rhino relies on Node.js to provide tools for working with JavaScript & Sass.
 You can read more in [Explanation: Node.js - JavaScript and Sass tools](https://appsilon.github.io/rhino/articles/explanation/node-js-javascript-and-sass-tools.html).
 To use these tools on Windows 10, you need to:
 
-1. [Install Node.js and yarn](https://go.appsilon.com/rhino-system-dependencies).
+1. [Install Node.js and Yarn](https://go.appsilon.com/rhino-system-dependencies).
 1. Enable [Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#active-developer-mode).

--- a/vignettes/tutorial/create-your-first-rhino-app.Rmd
+++ b/vignettes/tutorial/create-your-first-rhino-app.Rmd
@@ -21,14 +21,19 @@ install.packages("rhino")
 
 This tutorial uses the native pipe operator (`|>`) introduced in R 4.1 release. If you use an earlier R version, then you can use the `%>%` pipe operator found in `{magrittr}` and `{dplyr}` packages instead.
 
-Development tools for JavaScript and Sass, provided by Rhino, require [Node.js](https://nodejs.org/en/) and [yarn](https://yarnpkg.com/). Please follow installation guides for your OS:
+To use the state of the art JavaScript and Sass development tools provided by Rhino,
+you'll need to have Node.js and Yarn available on your system.
+Follow the links for installation instructions:
 
-* [Node.js installation guide](https://nodejs.org/en/download/)
-* [yarn installation guide](https://yarnpkg.com/getting-started/install)
+* [Node.js](https://nodejs.org/en/download/).
+You need v12 or later.
+* [Yarn](https://classic.yarnpkg.com/lang/en/).
+You need v1 (Yarn Classic). **Yarn v2 and later won't work**.
 
-Don't be discouraged if you are not able to get Node.js and yarn on your machine. Rhino will still work for you (with some small limitations described in [JavaScript](#add-javascript-code) and [Sass](#add-custom-styles) sections).
-
-**Note:** *If you already have node installed on your machine, make sure that you are using version \>=12.0.0.*
+Don't be discouraged if you are not able to get Node.js and Yarn on your machine.
+Rhino will still work for you
+(with some small limitations described in
+[JavaScript](#add-javascript-code) and [Sass](#add-custom-styles) sections).
 
 ----
 


### PR DESCRIPTION
### Changes
Closes #360. Note: Probably we could also make Rhino work with Yarn v2+ but it's not worth the effort: we're going to replace `yarn` with `npm` anyway (#104).
