### PR TITLE
Feat: Upgrade to `lintr >= 3.0.0.`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9006
+Version: 1.1.1.9007
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
   config,
   fs,
   glue,
-  lintr (>= 2.0.0),
+  lintr (>= 3.0.0),
   logger,
   purrr,
   renv,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9005
+Version: 1.1.1.9006
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Use R version from the lockfile in CI.
 * Dropped dependency on Yarn - only Node.js is now required.
 * Upgraded to `r-lib/actions/setup-r@v2`.
+* Upgraded to `lintr >= 3.0.0`.
 
 # [rhino 1.1.1](https://github.com/Appsilon/rhino/releases/tag/v1.1.1)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Included `build_js()` and `build_sass()` in template CI.
 * Use R version from the lockfile in CI.
 * Dropped dependency on Yarn - only Node.js is now required.
+* Upgraded to `r-lib/actions/setup-r@v2`.
 
 # [rhino 1.1.1](https://github.com/Appsilon/rhino/releases/tag/v1.1.1)
 

--- a/inst/templates/app_structure/dot.lintr
+++ b/inst/templates/app_structure/dot.lintr
@@ -1,6 +1,5 @@
 linters:
   linters_with_defaults(
     line_length_linter = line_length_linter(100),
-    infix_spaces_linter = NULL,
-    object_usage_linter = NULL
+    object_usage_linter = NULL  # Does not work with `box::use()`.
   )

--- a/inst/templates/app_structure/dot.lintr
+++ b/inst/templates/app_structure/dot.lintr
@@ -1,5 +1,5 @@
 linters:
-  with_defaults(
+  linters_with_defaults(
     line_length_linter = line_length_linter(100),
     infix_spaces_linter = NULL,
     object_usage_linter = NULL

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -16,7 +16,7 @@ jobs:
         run: printf 'R_VERSION=%s\n' "$(jq --raw-output .R.Version renv.lock)" >> $GITHUB_ENV
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ env.R_VERSION }}
 

--- a/vignettes/tutorial/create-your-first-rhino-app.Rmd
+++ b/vignettes/tutorial/create-your-first-rhino-app.Rmd
@@ -23,6 +23,8 @@ This tutorial uses the native pipe operator (`|>`) introduced in R 4.1 release. 
 
 To use the state of the art JavaScript and Sass development tools provided by Rhino,
 you'll need to [install Node.js](https://nodejs.org/en/download/) (v12 or later) on your system.
+On Windows you'll also need to enable
+[Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#active-developer-mode).
 
 Rhino will still work without Node.js but with some limitations
 (described in [JavaScript](#add-javascript-code) and [Sass](#add-custom-styles) sections).


### PR DESCRIPTION
### Changes
Closes #335 
* Requires `lintr >= 3.0.0` in DESCRIPTION.
* Replaces deprecated `with_defaults()` with `linters_with_defaults()` in `inst/templates/app_structure/dot.lintr`.

- [x]  `rhino::lint_r()` runs cleanly on a freshly initialized Rhino project.

### Notes
* I checked the [release notes](https://www.tidyverse.org/blog/2022/07/lintr-3-0-0/). The major changes should not affect the default linter settings defined in `inst/templates/app_structure/dot.lintr`. 
* We are not using `linters` argument in our use of `lintr::lint()` and `lintr::lint_dir()`, so there should no be issues with `lintr`'s shift to function factories. 
* Users with custom linters may need to update to function factories, if they have not yet. 
* I tested with some codes in `app/logic`, `app/view`, and `tests`. I can confirm `rhino::lint_r()` still works as expected, and throws error for some basic bad styling I tested.

### How to test
* Create new Rhino app with `rhino::init()`
* `rhino::lint_r()` should detect no lint errors.