### PR TITLE
Feat: Upgrade rlib actions setup r v2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9005
+Version: 1.1.1.9006
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Included `build_js()` and `build_sass()` in template CI.
 * Use R version from the lockfile in CI.
 * Dropped dependency on Yarn - only Node.js is now required.
+* Upgraded to `r-lib/actions/setup-r@v2`.
 
 # [rhino 1.1.1](https://github.com/Appsilon/rhino/releases/tag/v1.1.1)
 

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -16,7 +16,7 @@ jobs:
         run: printf 'R_VERSION=%s\n' "$(jq --raw-output .R.Version renv.lock)" >> $GITHUB_ENV
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ env.R_VERSION }}
 


### PR DESCRIPTION
### Changes
Closes #364 

* `inst/templates/github_ci/dot.github/workflows/rhino-test.yml` should now use `r-lib/actions/setup-r@v2`.

### How to test
* Example [passing `rhino-showcase` CI ](https://github.com/Appsilon/rhino-showcase/actions/runs/3476958502/jobs/5812654304)with `r-lib/actions/setup-r@v2`.