### PR TITLE
Feat: Silence `npm install` messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9007
+Version: 1.1.1.9008
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/R/node.R
+++ b/R/node.R
@@ -52,7 +52,7 @@ npm <- function(...) {
   )
   if (!fs::dir_exists(node_path())) {
     add_node()
-    system_npm(c("install", "--silent"))
+    system_npm(c("install", "--loglevel", "error"))
   }
   system_npm(...)
 }

--- a/R/node.R
+++ b/R/node.R
@@ -52,7 +52,7 @@ npm <- function(...) {
   )
   if (!fs::dir_exists(node_path())) {
     add_node()
-    system_npm("install")
+    system_npm(c("install", "--silent"))
   }
   system_npm(...)
 }


### PR DESCRIPTION
### Changes
Closes #380 

* Initial `npm install` should no longer show messages including audits/security alerts, but should not fail silently.
### How to test

* Create fresh Rhino project, `rhino::init()`
* Run `rhino::lint_js()`
* `npm` should install all package dependencies and not show any messages including security alerts.
