### PR TITLE
Run `npm install` silently

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.1.1.9007
+Version: 1.1.1.9008
 Authors@R:
   c(
     person("Kamil", "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Dropped dependency on Yarn - only Node.js is now required.
 * Upgraded to `r-lib/actions/setup-r@v2`.
 * Upgraded to `lintr >= 3.0.0`.
+* Silence audit and funding messages when using Node.js.
 
 # [rhino 1.1.1](https://github.com/Appsilon/rhino/releases/tag/v1.1.1)
 

--- a/R/node.R
+++ b/R/node.R
@@ -1,10 +1,5 @@
-system_npm <- function(..., status_ok = 0) {
-  withr::with_dir(node_path(), {
-    status <- system2(command = "npm", args = c(...))
-  })
-  if (status != status_ok) {
-    cli::cli_abort("System command 'npm' exited with status {status}.")
-  }
+node_path <- function(...) {
+  fs::path(".rhino", "node", ...)
 }
 
 link_root_mklink <- function() {
@@ -44,6 +39,17 @@ add_node <- function(clean = FALSE) {
   })
 }
 
+# Run `npm` command (assume node directory already exists in the project).
+npm_raw <- function(..., status_ok = 0) {
+  withr::with_dir(node_path(), {
+    status <- system2(command = "npm", args = c(...))
+  })
+  if (status != status_ok) {
+    cli::cli_abort("System command 'npm' exited with status {status}.")
+  }
+}
+
+# Run `npm` command (create node directory in the project if needed).
 npm <- function(...) {
   check_system_dependency(
     cmd = "node",
@@ -52,7 +58,7 @@ npm <- function(...) {
   )
   if (!fs::dir_exists(node_path())) {
     add_node()
-    system_npm("install", "--no-audit", "--no-fund")
+    npm_raw("install", "--no-audit", "--no-fund")
   }
-  system_npm(...)
+  npm_raw(...)
 }

--- a/R/node.R
+++ b/R/node.R
@@ -52,7 +52,7 @@ npm <- function(...) {
   )
   if (!fs::dir_exists(node_path())) {
     add_node()
-    system_npm("install")
+    system_npm("install", "--no-audit", "--no-fund")
   }
   system_npm(...)
 }

--- a/R/rhino.R
+++ b/R/rhino.R
@@ -1,7 +1,3 @@
-node_path <- function(...) {
-  fs::path(".rhino", "node", ...)
-}
-
 rename_template_path <- function(path) {
   path <- fs::path_split(path)[[1]]
   path <- sub("^dot\\.", ".", path)


### PR DESCRIPTION
### Changes
Closes #380:
1. Run `npm install` with `--no-audit` and `--no-funding` flags to avoid confusing / nonactionable messages when using Node.js tools.
2. Refactor the code in `R/node.R` a bit.

### How to test
In a fresh Rhino project run `rhino::lint_js()`. It should only output a string like `added 758 packages in 8s`.