### PR TITLE
Fix: fix with_head_tags fun stability in the bookmarking case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Developer Mode is no longer needed on Windows to use Node.js tools.
 * The `build_js()` and `build_sass()` functions should now work on Windows with `watch = TRUE`.
 * The `lint_js()` function should now work on Windows when imports are used in JavaScript.
+* Improve behavior of with_head_tags() it won't cause problems with `legacy_entrypoint: source`
 
 # [rhino 1.1.1](https://github.com/Appsilon/rhino/releases/tag/v1.1.1)
 

--- a/R/app.R
+++ b/R/app.R
@@ -66,7 +66,7 @@ attach_head_tags <- function(ui) {
 
 with_head_tags <- function(ui) {
   # The top-level UI must be a function for Shiny bookmarking to work.
-  if (is.function(ui)) function(request) attach_head_tags(ui(request))
+  if (is.function(ui)) function() attach_head_tags(ui())
   else attach_head_tags(ui)
 }
 

--- a/vignettes/how-to/enable-shiny-bookmarking.Rmd
+++ b/vignettes/how-to/enable-shiny-bookmarking.Rmd
@@ -36,5 +36,6 @@ server <- function(id) {
 ```
 
 If you are using a [legacy entrypoint](https://appsilon.github.io/rhino/reference/app.html#legacy-entrypoint),
-be sure to make your UI a function
-as described in the details section of `shiny::enableBookmarking()`.
+be sure to make your UI a function with `request` parameter that has nothing
+declared
+(as described in the details section of `shiny::enableBookmarking()`).

--- a/vignettes/how-to/enable-shiny-bookmarking.Rmd
+++ b/vignettes/how-to/enable-shiny-bookmarking.Rmd
@@ -36,6 +36,17 @@ server <- function(id) {
 ```
 
 If you are using a [legacy entrypoint](https://appsilon.github.io/rhino/reference/app.html#legacy-entrypoint),
-be sure to make your UI a function with `request` parameter that has nothing
-declared
-(as described in the details section of `shiny::enableBookmarking()`).
+be sure to make your UI a function
+as described in the details section of `shiny::enableBookmarking()`.
+It should take `request` as a parameter,
+though it shouldn't be used in any way in the function body.
+
+For example, with `legacy_entrypoint: source` in `rhino.yml` you might use:
+```r
+ui <- function(request) {
+  bootstrapPage(
+    bookmarkButton(),
+    textField("text", "Text")
+  )
+}
+```


### PR DESCRIPTION
### Acceptance criteria

- [x] improve behaviour of `with_head_tags` function so it won't cause more problems
- [x] added explanation to documentation in bookmarking vignette

### Changes
Closes #283 

### How to test
```
# change legacy_entrypoint to source in config
# this should now work

library(shiny)

ui <- function() {
  bootstrapPage(
    tags$h3(
      "Test"
    )
  )
}

server <- function(input, output, session) {
}
```