### PR TITLE
Feat: Create `js` alias for `root/app/js`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.2.1
+Version: 1.2.1.9000
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rhino (development version)
+
+1. Allow importing JavaScript relative to `app/js` using the `js` alias.
+
 # rhino 1.2.1
 
 1. Fix Rhino GitHub Actions (Cypress used to fail).

--- a/inst/templates/node/dot.eslintrc.json
+++ b/inst/templates/node/dot.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "parser": "@babel/eslint-parser",
-  "parserOptions": {
-    "requireConfigFile": false
-  },
   "extends": ["airbnb-base"],
   "env": {
     "browser": true
@@ -14,21 +11,13 @@
   "settings": {
     "import/resolver": {
       "webpack": {
-        "config": "./webpack.config.babel.js"
+        "config": "./webpack.config.js"
       }
     }
   },
   "rules": {
     "import/prefer-default-export": "off",
     "no-alert": "off",
-    "no-console": "off",
-    "import/no-extraneous-dependencies": [
-      "warn",
-      {
-        "devDependencies": true,
-        "optionalDependencies": true,
-        "peerDependencies": true
-      }
-    ]
+    "no-console": "off"
   }
 }

--- a/inst/templates/node/dot.eslintrc.json
+++ b/inst/templates/node/dot.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "requireConfigFile": false
+  },
   "extends": ["airbnb-base"],
   "env": {
     "browser": true
@@ -8,9 +11,24 @@
     "$": "readonly",
     "Shiny": "readonly"
   },
+  "settings": {
+    "import/resolver": {
+      "webpack": {
+        "config": "./webpack.config.babel.js"
+      }
+    }
+  },
   "rules": {
     "import/prefer-default-export": "off",
     "no-alert": "off",
-    "no-console": "off"
+    "no-console": "off",
+    "import/no-extraneous-dependencies": [
+      "warn",
+      {
+        "devDependencies": true,
+        "optionalDependencies": true,
+        "peerDependencies": true
+      }
+    ]
   }
 }

--- a/inst/templates/node/webpack.config.js
+++ b/inst/templates/node/webpack.config.js
@@ -5,6 +5,11 @@ const appDir = join(__dirname, '..', 'app');
 module.exports = {
   mode: 'production',
   entry: join(appDir, 'js', 'index.js'),
+  resolve: {
+    alias: {
+      js: resolve(__dirname, 'root/app/js'),
+    },
+  },
   output: {
     library: 'App',
     path: join(appDir, 'static', 'js'),

--- a/inst/templates/node/webpack.config.js
+++ b/inst/templates/node/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   entry: join(appDir, 'js', 'index.js'),
   resolve: {
     alias: {
-      js: resolve(__dirname, 'root', 'app', 'js'),
+      js: resolve(appDir, 'js'),
     },
   },
   output: {

--- a/inst/templates/node/webpack.config.js
+++ b/inst/templates/node/webpack.config.js
@@ -1,4 +1,5 @@
 const { join } = require('path');
+const { resolve } = require('path');
 
 const appDir = join(__dirname, '..', 'app');
 

--- a/inst/templates/node/webpack.config.js
+++ b/inst/templates/node/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   entry: join(appDir, 'js', 'index.js'),
   resolve: {
     alias: {
-      js: resolve(__dirname, 'root/app/js'),
+      js: resolve(__dirname, 'root', 'app', 'js'),
     },
   },
   output: {


### PR DESCRIPTION
### Changes
Closes #77 

### How to test

* Build and install Rhino 1.2.1.9000 using this branch.
* Create a new Rhino project.
* Create JS modules in `app/js` or subdirectories in `app/js`.
* Import modules relative to `app/js` using `js` alias. E.g. if module is in `app/js`, use `js/name_of_module`; if module is in `app/js/dir`, use `js/dir/name_of_module`.
* `rhino::lint_js()` and `rhino::build_js()` should work.
