### PR TITLE
Shinytest2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.2.1.9000
+Version: 1.2.1.9001
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rhino (development version)
 
+1. Rhino now works with `shinytest2` out of the box.
+
 # [rhino 1.2.1](https://github.com/Appsilon/rhino/releases/tag/v1.2.1)
 
 1. Fix Rhino GitHub Actions (Cypress used to fail).

--- a/R/app.R
+++ b/R/app.R
@@ -1,3 +1,11 @@
+setup_box_path <- function() {
+  # Normally `box.path` is set in `.Rprofile` and used for the whole R session,
+  # however `shinytest2` launches the application in a new process which doesn't source `.Rprofile`.
+  if (is.null(getOption("box.path"))) {
+    options(box.path = getwd())
+  }
+}
+
 # Make it possible to reload the app without restarting the R session.
 purge_box_cache <- function() {
   loaded_mods <- loadNamespace("box")$loaded_mods
@@ -115,6 +123,7 @@ with_head_tags <- function(ui) {
 #' }
 #' @export
 app <- function() {
+  setup_box_path()
   purge_box_cache()
   configure_logger()
   shiny::addResourcePath("static", fs::path_wd("app", "static"))

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -40,9 +40,9 @@ roxygen
 rstudio
 scalable
 shinyapps
+shinytest
 ui
 unintuitive
 usethis
 webpack
 yml
-Żyła

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -58,6 +58,8 @@ navbar:
           href: articles/how-to/keep-multiple-apps-in-a-single-repository.html
         - text: Use global variables
           href: articles/how-to/use-global-variables.html
+        - text: Use shinytest2
+          href: articles/how-to/use-shinytest2.html
 
 reference:
 - title: Project initialization

--- a/vignettes/how-to/use-shinytest2.Rmd
+++ b/vignettes/how-to/use-shinytest2.Rmd
@@ -1,0 +1,28 @@
+---
+title: "How-to: Use shinytest2"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{How-to: Use shinytest2}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+If you have Node.js available on your machine,
+you can write end-to-end tests using [Cypress](https://www.cypress.io/)
+and run them with `rhino::test_e2e()` without any additional setup.
+If you'd prefer to use the `shinytest2` package instead, you will need to:
+
+1. Install `shinytest2` and `shinyvalidate`.
+    1. Add `library(shinytest2)` and `library(shinyvalidate)` lines to your `dependencies.R`.
+    2. Install the packages with `renv::install(c("shinytest2", "shinyvalidate"))`.
+    3. Update the lockfile with `renv::snapshot()`.
+2. Create a test with `shinytest2::record_test()` or `shinytest2::use_shinytest2_test()` as usual.
+3. Optionally you can remove the following files created by `shinytest2`,
+which are unnecessary in Rhino:
+    1. Runner (`tests/testthat.R`),
+    used in R packages and executed by `R CMD check`.
+    2. Setup (`tests/testthat/setup-shinytest2.R`),
+    used in traditional Shiny applications with `global.R` and sources in the `R` directory.
+
+The tests created by `shinytest2` are treated as any other `testthat` tests
+and can be run with `rhino::test_r()`.


### PR DESCRIPTION
### Changes
Closes #346:
1. Setup `box.path` in `rhino::app()` so that `box` imports work when the application is launched by `shinytest2`.
2. Document how `shinytest2` tests can be added to a Rhino app.

### How to test
1. Initialize a fresh Rhino application and add at least one import, e.g. `box::use(app/logic)` in `main.R`.
2. Follow the instructions in the vignette to create a simple test.
3. Ensure the test runs cleanly with `rhino::test_r()`.