### PR TITLE
App push test

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,21 +23,45 @@ This document contains guidelines specific to Rhino.
 6. Build package<br>
 `devtools::build()` or `pkgbuild::build()`
 
+## App Push Test
+
+Rhino creates a `.github/workflows/rhino-test.yml` file on `rhino::init()`.
+This GitHub Actions workflow automatically runs all linters and tests
+once a project is pushed to GitHub.
+To test that it works correctly we have the [App Push Test](https://github.com/Appsilon/rhino/actions/workflows/app-push-test.yml) workflow.
+
+The Push Test initializes a fresh Rhino application and pushes it to the `bot/app-push-test` branch.
+The Rhino Test of this application then runs and its results can be viewed
+in the [list of workflow runs](https://github.com/Appsilon/rhino/actions/workflows/rhino-test.yml).
+The App Push Test is triggered automatically on pushes to `main` and can also be triggered manually.
+
 ## Release process
 
 ### Preparation
 
-1. Announce the planned release on `#proj-rhino`
-(approximate date and scope).
-2. Bump the package version in `DESCRIPTION` according to [SemVer](https://semver.org/).
-Drop the development version (last component, e.g. `.9001`).
-3. Update `NEWS.md`.
-    1. Replace the `(development version)` with `X.Y.Z` in the header.
-    Do add a link to GitHub releases yet - the link won't work and will fail CRAN checks.
-    2. Edit the list of changes to make it useful and understandable for our users.
-    See [keep a changelog](https://keepachangelog.com/) for some guidelines.
-4. Submit the changes in a pull request titled "Release X.Y.Z".
-Get it approved and merged.
+1. Announce the planned release on `#proj-rhino` (approximate date and scope).
+2. Plan promotion (social media, blog post, ...).
+Coordinate efforts with the marketing team.
+3. Ensure that the [App Push Test](#app-push-test) passes
+(the [latest run](https://github.com/Appsilon/rhino/actions/workflows/rhino-test.yml)
+for the `main` branch should be green).
+4. Upgrade [Rhino Showcase](https://github.com/Appsilon/rhino-showcase).
+    1. Create a task to track progress.
+    2. Test upgrade by installing Rhino from the current `main` branch.
+    3. Continue the release process.
+    The upgrade can be completed and the task closed once the package is accepted to CRAN.
+5. Prepare the package for release.
+    1. Create a `release-X.Y.Z` branch from `main`.
+    2. Update `DESCRIPTION`.
+        * Bump the package version according to [SemVer](https://semver.org/).
+        Drop the development version (last component, e.g. `.9001`).
+    3. Update `NEWS.md`.
+        * Replace the `(development version)` with `X.Y.Z` in the header.
+        Do not add a link to GitHub releases yet - the link won't work and will fail CRAN checks.
+        * Edit the list of changes to make it useful and understandable for our users.
+        See [keep a changelog](https://keepachangelog.com/) for some guidelines.
+    4. Submit the changes in a pull request titled "Release X.Y.Z".
+    Get it approved and merged.
 
 ### Submitting to CRAN
 
@@ -50,11 +74,15 @@ Get it approved and merged.
     1. Create a new `vX.Y.Z-rc.1` tag on the `main` branch (`rc` stands for release candidate).
     2. Use the tag name for title.
     3. Leave description blank.
+    4. Check "Set as a pre-release".
+    5. Click "Publish release".
 3. [Submit the package to CRAN](https://cran.r-project.org/submit.html).
     1. Use your own name and email.
-    2. Click the confirmation link sent to `opensource@appsilon.com`.
-4. If CRAN reviewers ask for changes,
-implement them and return to step 1.
+    2. Click "Choose File" and select `rhino_X.Y.Z.tar.gz` from step 1.
+    3. Click "Upload the package".
+    4. Click "Submit package".
+    5. Click the confirmation link sent to `opensource@appsilon.com`.
+4. If CRAN reviewers ask for changes, implement them and return to step 1.
 Use `rc.2`, `rc.3` and so on for subsequent submissions.
 
 ### Once accepted to CRAN
@@ -63,13 +91,13 @@ Use `rc.2`, `rc.3` and so on for subsequent submissions.
     1. Create a new `vX.Y.Z` tag on the `main` branch.
     2. Use the tag name for title.
     3. Fill in the description from `NEWS.md`.
+    4. Check "Set as the latest release".
+    5. Click "Publish release".
 2. Prepare the package for further development.
     1. Add a development version `.9000` in `DESCRIPTION`.
     2. Add a `# rhino (development version)` header in `NEWS.md`.
     3. Link the `# rhino X.Y.Z` header to the GitHub release in `NEWS.md`.
-3. Create a task to upgrade [Rhino Showcase](https://github.com/Appsilon/rhino-showcase).
-4. Announce the release on `#proj-rhino`.
-5. Plan promotion (social media, blog post, ...).
+3. Announce the release on `#proj-rhino`.
 
 ## Development process
 

--- a/.github/workflows/app-push-test.yml
+++ b/.github/workflows/app-push-test.yml
@@ -1,0 +1,45 @@
+# This workflow initializes a fresh Rhino app and pushes it to a dedicated orphan branch.
+# This way we can test the app CI (the GitHub Actions workflow created on `rhino::init()`).
+name: App Push Test
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+jobs:
+  main:
+    name: Push fresh app
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BRANCH_NAME: bot/app-push-test
+    steps:
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install Rhino
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: Appsilon/rhino@${{ github.sha }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          # The default GITHUB_PAT has insufficient permissions to push workflow changes.
+          # The token passed here must have write access to code and workflows.
+          token: ${{ secrets.APP_PUSH_TEST_PAT }}
+
+      - name: Prepare branch
+        run: git switch --orphan "$BRANCH_NAME"
+
+      - name: Initialize app
+        shell: Rscript {0}
+        run: rhino::init()
+
+      - name: Push branch
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add .
+          git commit --message "App Push Test ($GITHUB_REF_NAME)"
+          git push --force origin "$BRANCH_NAME"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 > _Build high quality, enterprise-grade [Shiny](https://shiny.rstudio.com/) apps at speed._
 
 <!-- badges: start -->
-[![CRAN status](https://www.r-pkg.org/badges/version/rhino)](https://cran.r-project.org/package=rhino)
-[![CI status](https://github.com/Appsilon/rhino/actions/workflows/ci.yml/badge.svg)](https://github.com/Appsilon/rhino/actions/workflows/ci.yml)
-[![cranlogs](https://cranlogs.r-pkg.org/badges/rhino)](https://CRAN.R-project.org/package=rhino)
-[![total](https://cranlogs.r-pkg.org/badges/grand-total/rhino)](https://CRAN.R-project.org/package=rhino)
+[![CRAN](https://www.r-pkg.org/badges/version/rhino)](https://cran.r-project.org/package=rhino)
+[![CI](https://github.com/Appsilon/rhino/actions/workflows/ci.yml/badge.svg)](https://github.com/Appsilon/rhino/actions/workflows/ci.yml)
+[![Rhino Test](https://github.com/Appsilon/rhino/actions/workflows/rhino-test.yml/badge.svg?branch=bot%2Fapp-push-test)](https://github.com/Appsilon/rhino/actions/workflows/rhino-test.yml)
+[![downloads monthly](https://cranlogs.r-pkg.org/badges/rhino)](https://CRAN.R-project.org/package=rhino)
+[![downloads total](https://cranlogs.r-pkg.org/badges/grand-total/rhino)](https://CRAN.R-project.org/package=rhino)
 [![License: LGPL-3.0](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](https://opensource.org/licenses/LGPL-3.0)
 <!--
 [![codecov](https://codecov.io/gh/Appsilon/rhino/branch/main/graph/badge.svg)](https://codecov.io/gh/Appsilon/rhino) 


### PR DESCRIPTION
### Changes
Addresses #58, but does not close it.
1. Create a new App Push Test workflow.
2. Add a status badge to `README`.
3. Document the test and update release instructions.

### How to test
See the example runs of [App Push Test](https://github.com/Appsilon/rhino/actions/runs/3647938621) and [Rhino Test](https://github.com/Appsilon/rhino/actions/runs/3648006744) triggered by it.