### PR TITLE
Link to shinytest2 how-to guide from `test_e2e()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ BugReports: https://github.com/Appsilon/rhino/issues
 License: LGPL-3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends:
   R (>= 2.10)
 Imports:

--- a/R/tools.R
+++ b/R/tools.R
@@ -192,7 +192,7 @@ build_js <- function(watch = FALSE) {
   }
 }
 
-# nolint start
+# nolint start: line_length_linter
 #' Lint JavaScript
 #'
 #' Runs [ESLint](https://eslint.org) on the JavaScript sources in the `app/js` directory.

--- a/R/tools.R
+++ b/R/tools.R
@@ -322,6 +322,10 @@ lint_sass <- function(fix = FALSE) {
 #' defined in the `tests/cypress` directory.
 #' Requires Node.js to be available on the system.
 #'
+#' If you want to write end-to-end tests with `{shinytest2}`, see our
+#' [How-to: Use shinytest2](https://appsilon.github.io/rhino/articles/how-to/use-shinytest2.html)
+#' guide.
+#'
 #' @param interactive Should Cypress be run in the interactive mode?
 #' @return None. This function is called for side effects.
 #'

--- a/man/test_e2e.Rd
+++ b/man/test_e2e.Rd
@@ -17,6 +17,11 @@ Uses \href{https://www.cypress.io/}{Cypress} to run end-to-end tests
 defined in the \code{tests/cypress} directory.
 Requires Node.js to be available on the system.
 }
+\details{
+If you want to write end-to-end tests with \code{{shinytest2}}, see our
+\href{https://appsilon.github.io/rhino/articles/how-to/use-shinytest2.html}{How-to: Use shinytest2}
+guide.
+}
 \examples{
 if (interactive()) {
   # Run the end-to-end tests in the `tests/cypress` directory.


### PR DESCRIPTION
### Changes
1. Add a link to "How-to: Use shinytest2" guide to `test_e2e()` docs.
2. Upgrade Roxygen to `7.2.3` in `DESCRIPTION`.
3. Limit the `nolint start` scope to `line_length_linter`.