### PR TITLE
Add purge_box_cache() in test_r()

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -11,6 +11,7 @@
 #' }
 #' @export
 test_r <- function() {
+  purge_box_cache()
   testthat::test_dir(fs::path("tests", "testthat"))
 }
 


### PR DESCRIPTION
Clean environment of box modules before running tests to avoid box::reload() calls in test files.

