### PR TITLE
Fix spelling

### DIFF
--- a/vignettes/how-to/use-shinymanager.Rmd
+++ b/vignettes/how-to/use-shinymanager.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-Rhino puts strong emphasis on modularisation
+Rhino puts strong emphasis on modularization
 and for consistency even the outermost UI and server are defined as a Shiny module.
 Unfortunately, [`shinymanager::secure_app()`](https://datastorm-open.github.io/shinymanager/reference/secure-app.html)
 cannot be placed in a Shiny module as it is designed to be passed directly to `shiny::shinyApp()`.


### PR DESCRIPTION
### Changes

Fix CI: use US spelling for "modularization" (vs. modularisation).
