### PR TITLE
Fix pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -14,13 +14,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-
       - name: Install R
         uses: r-lib/actions/setup-r@v2
         with:
-          use-public-rspm: true
+          use-public-rspm: true # Dramatically speeds up installation of dependencies.
 
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
@@ -32,8 +29,8 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Deploy to branch
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and deploy site
         shell: Rscript {0}
         run: pkgdown::deploy_to_branch(branch = "bot/github-pages")
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -105,6 +105,8 @@ reference:
 
 - title: R development
   contents:
+  - dependency_add
+  - dependency_remove
   - log
   - format_r
   - lint_r


### PR DESCRIPTION
### Changes

1. Fix pkgdown (it's failing on `main`) by adding missing entries to the reference index.
2. Refresh the workflow (remove unnecessary pandoc install, improve readability).

### How to test

See a [test run](https://github.com/Appsilon/rhino/actions/runs/5290131600/jobs/9573903805) of this workflow.