### PR TITLE
replace dataset calls in rhino tutorials with box

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ RoxygenNote: 7.2.3
 Depends:
   R (>= 2.10)
 Imports:
-  box,
+  box (>=1.1.3),
   cli,
   config,
   fs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ RoxygenNote: 7.2.3
 Depends:
   R (>= 2.10)
 Imports:
-  box (>=1.1.3),
+  box (>= 1.1.3),
   cli,
   config,
   fs,

--- a/vignettes/explanation/box-modules.Rmd
+++ b/vignettes/explanation/box-modules.Rmd
@@ -190,11 +190,11 @@ box::use(
 # Known issues
 
 ### Lazy-loaded data
-Box 1.1.0 doesn't support lazy-loaded [data](https://r-pkgs.org/data.html#data-data),
-so e.g. `box::use(datasets[mtcars])` won't work.
-This feature should be available in the next release
-(see this [issue](https://github.com/klmr/box/issues/219)).
-For now please use `datasets::mtcars` in your code.
+Starting from `box>=1.1.3`, you can now import datasets directly without using `rhino::rhinos`.
+If you are using `box>=1.1.3`, there is no need to modify the code and you can proceed with dataset imports as usual.
+Please note that in `box 1.1.0`, lazy-loaded [data](https://r-pkgs.org/data.html#data-data) is not supported. Therefore, if you are using a version prior to `box 1.1.3`, you will need to use `datasets::mtcars` (or similar syntax) in your code to access the desired dataset.
+For more information, refer to this [issue](https://github.com/klmr/box/issues/219), which addresses the addition of lazy-loaded data support in the upcoming release.
+Ensure you have updated to `box>=1.1.3` for seamless dataset imports without the need for `rhino::rhinos`.
 
 ### Trailing commas
 Box 1.1.0 allows trailing commas in `box::use()` statements and code,

--- a/vignettes/explanation/box-modules.Rmd
+++ b/vignettes/explanation/box-modules.Rmd
@@ -190,11 +190,11 @@ box::use(
 # Known issues
 
 ### Lazy-loaded data
-Starting from `box>=1.1.3`, you can now import datasets directly without using `rhino::rhinos`.
-If you are using `box>=1.1.3`, there is no need to modify the code and you can proceed with dataset imports as usual.
-Please note that in `box 1.1.0`, lazy-loaded [data](https://r-pkgs.org/data.html#data-data) is not supported. Therefore, if you are using a version prior to `box 1.1.3`, you will need to use `datasets::mtcars` (or similar syntax) in your code to access the desired dataset.
-For more information, refer to this [issue](https://github.com/klmr/box/issues/219), which addresses the addition of lazy-loaded data support in the upcoming release.
-Ensure you have updated to `box>=1.1.3` for seamless dataset imports without the need for `rhino::rhinos`.
+Box 1.1.0 doesn't support lazy-loaded [data](https://r-pkgs.org/data.html#data-data),
+so e.g. `box::use(datasets[mtcars])` won't work.
+This feature should be available in the next release
+(see this [issue](https://github.com/klmr/box/issues/219)).
+For now please use `datasets::mtcars` in your code.
 
 ### Trailing commas
 Box 1.1.0 allows trailing commas in `box::use()` statements and code,

--- a/vignettes/explanation/box-modules.Rmd
+++ b/vignettes/explanation/box-modules.Rmd
@@ -190,6 +190,7 @@ box::use(
 # Known issues
 
 ### Lazy-loaded data
+The following issue is fixed in box v1.1.3. Rhino v1.4.0 requires box v1.1.3 or later
 Box 1.1.0 doesn't support lazy-loaded [data](https://r-pkgs.org/data.html#data-data),
 so e.g. `box::use(datasets[mtcars])` won't work.
 This feature should be available in the next release

--- a/vignettes/tutorial/create-your-first-rhino-app.Rmd
+++ b/vignettes/tutorial/create-your-first-rhino-app.Rmd
@@ -269,9 +269,8 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     output$chart <- echarts4r$renderEcharts4r(
-      # Datasets are the only case when you need to use :: in `box`.
-      # This issue should be solved in the next `box` release.
-      rhino::rhinos |>
+      # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
+      rhinos |>
         echarts4r$group_by(Species) |>
         echarts4r$e_chart(x = Year) |>
         echarts4r$e_line(Population) |>
@@ -384,9 +383,8 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
-    # Datasets are the only case when you need to use :: in `box`.
-    # This issue should be solved in the next `box` release.
-    data <- rhino::rhinos
+    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
+    data <- rhinos
 
     table$server("table", data = data)
     chart$server("chart", data = data)
@@ -689,9 +687,8 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
-    # Datasets are the only case when you need to use :: in `box`.
-    # This issue should be solved in the next `box` release.
-    data <- rhino::rhinos
+    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
+    data <- rhinos
 
     table$server("table", data = data)
     chart$server("chart", data = data)

--- a/vignettes/tutorial/create-your-first-rhino-app.Rmd
+++ b/vignettes/tutorial/create-your-first-rhino-app.Rmd
@@ -270,7 +270,6 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     output$chart <- echarts4r$renderEcharts4r(
-      # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
       rhinos |>
         echarts4r$group_by(Species) |>
         echarts4r$e_chart(x = Year) |>
@@ -385,7 +384,6 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
-    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
     data <- rhinos
 
     table$server("table", data = data)
@@ -690,7 +688,6 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
-    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
     data <- rhinos
 
     table$server("table", data = data)

--- a/vignettes/tutorial/create-your-first-rhino-app.Rmd
+++ b/vignettes/tutorial/create-your-first-rhino-app.Rmd
@@ -253,6 +253,7 @@ Add `echarts4r` render to the server part of the module and output part to its U
 box::use(
   echarts4r,
   shiny[h3, moduleServer, NS, tagList],
+  rhino[rhinos],
 )
 
 #' @export
@@ -364,6 +365,7 @@ We want to use the same dataset in both modules, so instead of calling it twice,
 
 box::use(
   shiny[bootstrapPage, moduleServer, NS],
+  rhino[rhinos],
 )
 box::use(
   app/view/chart,
@@ -665,6 +667,7 @@ Adjusting application style can be done by providing custom styles in the `app/s
 
 box::use(
   shiny[bootstrapPage, div, moduleServer, NS],
+  rhino[rhinos],
 )
 box::use(
   app/view/chart,


### PR DESCRIPTION
- In Rhino tutorials, dataset calls follow the ::  pattern due to a bug in the box  package. Since the bug has been fixed and the new version of box is available on CRAN, all ::  calls should be replaced with the proper box  import. 

### Changes
- replaced dataset calls in rhino tutorials with box imports


