### PR TITLE
Improve Rhino CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.5.0.9001
+Version: 1.5.0.9002
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 1. Cypress updated to version 13.
 2. `pkg_install` supports installation from local sources, GitHub, and Bioconductor.
+3. Update Rhino CI (use latest versions and make better use of actions).
 
 # [rhino 1.5.0](https://github.com/Appsilon/rhino/releases/tag/v1.5.0)
 

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -12,15 +12,18 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
+      - name: Setup system dependencies
+        run: |
+          packages=(
+            # List each package on a separate line.
+          )
+          sudo apt-get update
+          sudo apt-get install --yes "${packages[@]}"
+
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: renv
-
-      - name: Setup system dependencies
-        run: >
-          sudo apt-get update && sudo apt-get install --yes
-          libcurl4-openssl-dev
 
       - name: Restore renv from cache
         uses: actions/cache@v2

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -25,20 +25,8 @@ jobs:
         with:
           r-version: renv
 
-      - name: Restore renv from cache
-        uses: actions/cache@v2
-        env:
-          CACHE_KEY: renv-${{ runner.arch }}-${{ runner.os }}-${{ env.R_VERSION }}
-        with:
-          path: renv/library
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('renv.lock') }}
-          restore-keys: ${{ env.CACHE_KEY }}-
-
-      - name: Sync renv with lockfile
-        shell: Rscript {0}
-        run: |
-          options(renv.config.cache.symlinks = FALSE)
-          renv::restore(clean = TRUE)
+      - name: Setup R dependencies
+        uses: r-lib/actions/setup-renv@v2
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -12,13 +12,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Extract R version from lockfile
-        run: printf 'R_VERSION=%s\n' "$(jq --raw-output .R.Version renv.lock)" >> $GITHUB_ENV
-
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ env.R_VERSION }}
+          r-version: renv
 
       - name: Setup system dependencies
         run: >

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -6,8 +6,6 @@ jobs:
   main:
     name: Run linters and tests
     runs-on: ubuntu-22.04
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -5,12 +5,12 @@ permissions:
 jobs:
   main:
     name: Run linters and tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup system dependencies
         run: |
@@ -29,9 +29,9 @@ jobs:
         uses: r-lib/actions/setup-renv@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Lint R
         if: always()
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run Cypress end-to-end tests
         if: always()
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           working-directory: .rhino # Created by earlier commands which use Node.js
           start: npm run run-app


### PR DESCRIPTION
### Changes

Improve the CI workflow which comes with `rhino::init()`:

1. Drop the unnecessary `GITHUB_PAT` env variable.
2. Use the latest versions of Ubuntu, Node and actions.
3. Refactor the "Setup system dependencies" step:
    * Remove `libcurl4-openssl-dev` which is not actually needed.
    * Write out the install command using a bash array for readability. It is now possible to add comments to each entry.
5. Make better use of `setup-r` action options:
    * Use `r-version: renv` instead of a custom step to read R version from `renv.lock`.
6. Use the `setup-renv` action instead of custom steps for installing and caching dependencies from `renv.lock`.
    * This also resolves a problem with the current setup: the cache key does not include `renv` version, so an update can potentially break the workflow when `renv` tries to use the cache saved by an older version (discovered while working on an unrelated issue).

### Testing & notes

I have done the following testing of this PR:

1. Run [App Push Test](https://github.com/Appsilon/rhino/actions/runs/7128549445).
2. Manually [push to a fresh repository](https://github.com/kamilzyla/rhino-ci/actions).
    * Rhino app right after init and after installing `odbc`, `sf` and `plumber`.
    * Tested with `renv` `0.17.3` and `1.0.3`.

I have dropped `use-public-rspm: true` from this PR as it might lead to a failure during package installation if the latest CRAN version is not yet available on RSPM. It seems to only happen with older versions of `renv` (my theory: they did not save package source properly), but it requires more testing.

It is not obvious whether we still need the "Setup system dependencies"  step. Right now it doesn't actually install anything and everything still works even when packages like `sf` or `odbc` are added (does `renv` now handle system dependencies automatically?). Still, I'd rather leave this step for now just in case.