### PR TITLE
fix: Fixes failing Cypress E2E tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.4.0.9000
+Version: 1.4.0.9001
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # rhino (development version)
 
 1. Add Rstudio Addins for lint, build and test Sass, R and JavaScript. Updated new module Addin.
+1. Fixes timeout during Cypress E2E tests with GitHub Actions.
 
 # rhino 1.4.0
 

--- a/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
+++ b/inst/templates/github_ci/dot.github/workflows/rhino-test.yml
@@ -77,8 +77,10 @@ jobs:
 
       - name: Run Cypress end-to-end tests
         if: always()
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           working-directory: .rhino # Created by earlier commands which use Node.js
           start: npm run run-app
           project: ../tests
+          wait-on: 'http://localhost:3333/'
+          wait-on-timeout: 60


### PR DESCRIPTION
### Changes
Closes #483

- Changes GitHub Action from `cypress-io/github-action@v2` -> `cypress-io/github-action@v5`
- Adds `wait-on: 'http://localhost:3333/'`  and `wait-on-timeout: 60`  to options.

### How to test

The following Repo forks the original issue's example: https://github.com/andyquinterom/RhinoTestCIFail/actions/runs/5810450592

This implements the changes made.

