### PR TITLE
Style box imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.4.0.9001
+Version: 1.4.0.9002
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 1. Add Rstudio Addins for lint, build and test Sass, R and JavaScript. Updated new module Addin.
 1. Fixes timeout during Cypress E2E tests with GitHub Actions.
+1. `format_r` no longer adds spaces in `box` imports.
 
 # rhino 1.4.0
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -114,9 +114,7 @@ lint_r <- function(paths = NULL) {
 }
 
 rhino_style <- function() {
-  style <- styler::tidyverse_style()
-  style$space$style_space_around_math_token <- NULL
-  style
+  styler::tidyverse_style(math_token_spacing = styler::specify_math_token_spacing(zero = "'/'"))
 }
 
 #' Format R


### PR DESCRIPTION
### Changes
`rhino::format_r` will no longer add spaces around "/". This will prevent it from modifying paths in `box::use`.

### How to test
`rhino::format_r` should not modify `box::use` statements.