### PR TITLE
Minify sass in r

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.4.0.9002
+Version: 1.4.0.9003
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 1. Add Rstudio Addins for lint, build and test Sass, R and JavaScript. Updated new module Addin.
 1. Fixes timeout during Cypress E2E tests with GitHub Actions.
 1. `format_r` no longer adds spaces in `box` imports.
+1. `build_sass` minifies the CSS file also if using R `sass` package.
 
 # rhino 1.4.0
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -289,7 +289,8 @@ build_sass_r <- function() {
   sass::sass(
     input = sass::sass_file(fs::path("app", "styles", "main.scss")),
     output = fs::path(output_dir, "app.min.css"),
-    cache = FALSE
+    cache = FALSE,
+    options = sass::sass_options(output_style = "compressed")
   )
 }
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -32,6 +32,7 @@ linter
 linters
 lockfile
 minified
+minifies
 modularization
 modularize
 modularized

--- a/tests/testthat/helpers/main.scss
+++ b/tests/testthat/helpers/main.scss
@@ -1,0 +1,10 @@
+.components-container {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+
+  .component-box {
+    padding: 10px;
+    margin: 10px;
+  }
+}

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -1,0 +1,24 @@
+test_that("build_sass_r builds a minified CSS file out of a Sass file", {
+  wd <- getwd()
+
+  withr::with_tempdir({
+    fs::dir_create("app", "styles")
+    fs::file_copy(
+      fs::path(wd, "helpers", "main.scss"),
+      fs::path("app", "styles", "main.scss")
+    )
+
+    build_sass_r()
+
+    minified_css_path <- fs::path("app", "static", "css", "app.min.css")
+
+    expect_true(fs::file_exists(minified_css_path))
+
+    output <- readLines(minified_css_path)[[1]]
+  })
+
+  expect_equal(
+    output,
+    ".components-container{display:inline-grid;grid-template-columns:1fr 1fr;width:100%}.components-container .component-box{padding:10px;margin:10px}" # nolint: line_length_linter
+  )
+})


### PR DESCRIPTION
### Changes
Closes #490

### How to test
1. Initialize a new Rhino application
2. Fill `app/styles/main.scss` with some valid Sass code, e.g.:
```sass
.components-container {
  display: inline-grid;
  grid-template-columns: 1fr 1fr;
  width: 100%;

  .component-box {
    padding: 10px;
    margin: 10px;
  }
}
```
3. Set `sass` option in `rhino.yml` to "r".
4. Run `rhino::build_sass()`
5. `app/static/css.app.min.css` should be created and minified.