### PR TITLE
Enable package installation from GitHub, Bioconductor and local directory.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.5.0.9000
+Version: 1.5.0.9001
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # rhino (development)
 
 1. Cypress updated to version 13.
+2. `pkg_install` supports installation from local sources, GitHub, and Bioconductor.
 
 # [rhino 1.5.0](https://github.com/Appsilon/rhino/releases/tag/v1.5.0)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -64,6 +64,18 @@ extract_packages_names <- function(packages) {
 #'   # Update shiny to the latest version
 #'   rhino::pkg_install("shiny")
 #'
+#'   # Install a specific version of shiny
+#'   rhino::pkg_install("shiny@1.6.0")
+#'
+#'   # Install shiny.i18n package from GitHub
+#'   rhino::pkg_install("Appsilon/shiny.i18n")
+#'
+#'   # Install Biobase package from Bioconductor
+#'   rhino::pkg_install("bioc::Biobase")
+#'
+#'   # Install shiny from local source
+#'   rhino::pkg_install("~/path/to/shiny")
+#'
 #'   # Remove dplyr
 #'   rhino::pkg_remove("dplyr")
 #' }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -23,6 +23,7 @@ write_dependencies <- function(deps) {
 
 extract_package_name <- function(package) {
   if (grepl("@", package)) package <- strsplit(package, "@")[[1]][1]
+
   if (grepl("bioc::", package)) return(strsplit(package, "::")[[1]][2])
 
   if (grepl("/", package)) {

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -86,8 +86,9 @@ NULL
 #' @export
 pkg_install <- function(packages) {
   stopifnot(is.character(packages))
-  renv::install(packages)
   packages_names <- extract_packages_names(packages)
+  cli::cli_alert_info("Installing packages: {packages_names}.")
+  renv::install(packages)
   write_dependencies(c(packages_names, read_dependencies()))
   renv::snapshot()
   invisible()
@@ -97,8 +98,9 @@ pkg_install <- function(packages) {
 #' @export
 pkg_remove <- function(packages) {
   stopifnot(is.character(packages))
-  renv::remove(packages)
   packages_names <- extract_packages_names(packages)
+  cli::cli_alert_info("Removing packages: {packages_names}.")
+  renv::remove(packages)
   write_dependencies(setdiff(read_dependencies(), packages_names))
   renv::snapshot()
   invisible()

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -21,6 +21,22 @@ write_dependencies <- function(deps) {
   writeLines(deps, "dependencies.R")
 }
 
+extract_package_name <- function(package) {
+  if (grepl("@", package)) package <- strsplit(package, "@")[[1]][1]
+  if (grepl("bioc::", package)) return(strsplit(package, "::")[[1]][2])
+
+  if (grepl("/", package)) {
+    package_splited <- strsplit(package, "/")[[1]]
+    return(package_splited[length(package_splited)])
+  }
+
+  package
+}
+
+extract_packages_names <- function(packages) {
+  purrr::map_chr(packages, extract_package_name)
+}
+
 # nolint start: line_length_linter
 #' Manage dependencies
 #'
@@ -58,7 +74,8 @@ NULL
 pkg_install <- function(packages) {
   stopifnot(is.character(packages))
   renv::install(packages)
-  write_dependencies(c(packages, read_dependencies()))
+  packages_names <- extract_packages_names(packages)
+  write_dependencies(c(packages_names, read_dependencies()))
   renv::snapshot()
   invisible()
 }
@@ -68,7 +85,8 @@ pkg_install <- function(packages) {
 pkg_remove <- function(packages) {
   stopifnot(is.character(packages))
   renv::remove(packages)
-  write_dependencies(setdiff(read_dependencies(), packages))
+  packages_names <- extract_packages_names(packages)
+  write_dependencies(setdiff(read_dependencies(), packages_names))
   renv::snapshot()
   invisible()
 }

--- a/man/dependencies.Rd
+++ b/man/dependencies.Rd
@@ -37,6 +37,18 @@ to learn about the details of the setup used by Rhino.
   # Update shiny to the latest version
   rhino::pkg_install("shiny")
 
+  # Install a specific version of shiny
+  rhino::pkg_install("shiny@1.6.0")
+
+  # Install shiny.i18n package from GitHub
+  rhino::pkg_install("Appsilon/shiny.i18n")
+
+  # Install Biobase package from Bioconductor
+  rhino::pkg_install("bioc::Biobase")
+
+  # Install shiny from local source
+  rhino::pkg_install("~/path/to/shiny")
+
   # Remove dplyr
   rhino::pkg_remove("dplyr")
 }

--- a/tests/e2e/test-dependencies.R
+++ b/tests/e2e/test-dependencies.R
@@ -28,3 +28,60 @@ rhino::pkg_remove("dplyr")
 testthat::expect_false(is_installed("dplyr"))
 testthat::expect_identical(readLines("dependencies.R"), initial_dependencies)
 testthat::expect_identical(readLines("renv.lock"), initial_lockfile)
+
+# install package from GitHub
+
+initial_dependencies <- readLines("dependencies.R")
+initial_lockfile <- readLines("renv.lock")
+
+# Check initial state.
+testthat::expect_false(is_installed("shiny.i18n"))
+testthat::expect_false(any(initial_dependencies == "library(shiny.i18n)"))
+testthat::expect_false(any(initial_lockfile == '    "shiny.i18n": {'))
+
+# Install package and check if it was done correctly.
+rhino::pkg_install("Appsilon/shiny.i18n")
+testthat::expect_true(is_installed("shiny.i18n"))
+testthat::expect_setequal(
+  readLines("dependencies.R"),
+  c(initial_dependencies, "library(shiny.i18n)")
+)
+testthat::expect_contains(
+  readLines("renv.lock"),
+  '    "shiny.i18n": {'
+)
+
+# Remove package and check if we're back to initial state.
+rhino::pkg_remove("shiny.i18n")
+testthat::expect_false(is_installed("shiny.i18n"))
+testthat::expect_identical(readLines("dependencies.R"), initial_dependencies)
+testthat::expect_identical(readLines("renv.lock"), initial_lockfile)
+
+
+# install package from Bioconductor
+
+initial_dependencies <- readLines("dependencies.R")
+initial_lockfile <- readLines("renv.lock")
+
+# Check initial state.
+testthat::expect_false(is_installed("Biobase"))
+testthat::expect_false(any(initial_dependencies == "library(Biobase)"))
+testthat::expect_false(any(initial_lockfile == '    "Biobase": {'))
+
+# Install package and check if it was done correctly.
+rhino::pkg_install("bioc::Biobase")
+testthat::expect_true(is_installed("Biobase"))
+testthat::expect_setequal(
+  readLines("dependencies.R"),
+  c(initial_dependencies, "library(Biobase)")
+)
+testthat::expect_contains(
+  readLines("renv.lock"),
+  '    "Biobase": {'
+)
+
+# Remove package and check if we're back to initial state.
+rhino::pkg_remove("Biobase")
+testthat::expect_false(is_installed("Biobase"))
+testthat::expect_identical(readLines("dependencies.R"), initial_dependencies)
+testthat::expect_identical(readLines("renv.lock"), initial_lockfile)

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -26,3 +26,15 @@ describe("extract_packages_names", {
     expect_equal(extract_packages_names(c("shiny", "dplyr")), c("shiny", "dplyr"))
   })
 })
+
+describe("pkg_install", {
+  it("throws an error when the argument is not a character vector", {
+    expect_error(pkg_install(1))
+  })
+})
+
+describe("pkg_remove", {
+  it("throws an error when the argument is not a character vector", {
+    expect_error(pkg_remove(1))
+  })
+})

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -1,0 +1,28 @@
+describe("extract_package_name", {
+  it("returns the package name intact when using only the package name", {
+    expect_equal(extract_package_name("shiny"), "shiny")
+  })
+
+  it("returns the package name intact when using the package name and version", {
+    expect_equal(extract_package_name("shiny@1.6.0"), "shiny")
+  })
+
+  it("returns the package name when installing a package from GitHub", {
+    expect_equal(extract_package_name("r-lib/httr"), "httr")
+    expect_equal(extract_package_name("r-lib/testthat@c67018fa4970"), "testthat")
+  })
+
+  it("returns the package name when installing a package from a local path", {
+    expect_equal(extract_package_name("~/path/to/package"), "package")
+  })
+
+  it("returns the package name when installing a package from Bioconductor", {
+    expect_equal(extract_package_name("bioc::Biobase"), "Biobase")
+  })
+})
+
+describe("extract_packages_names", {
+  it("returns a vector of package names when installing multiple packages", {
+    expect_equal(extract_packages_names(c("shiny", "dplyr")), c("shiny", "dplyr"))
+  })
+})


### PR DESCRIPTION
### Changes
Closes #508 

### How to test
In a rhino project:
1. Try to install a package from GitHub (e.g. `rhino::pkg_install("Appsilon/shiny.i18n")`).
2. Try to install multiple packages from GitHub in one step (e.g. `rhino::pkg_install(c("Appsilon/shiny.i18n", "Appsilon/data.validator"))).
3. Try to install a specific version of a package (e.g. `rhino::pkg_install("shiny.router@0.3.0"))
4. Try to install a package from Bioconductor (e.g. `rhino::pkg_install("bioc::Biobase"))
5. Try to remove packages.

For each step, verify if the packages were installed, added to `renv.lock`, and added to `dependencies.R`.