### PR TITLE
Make Shiny Autoreload Work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.5.0.9003
+Version: 1.5.0.9004
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
     * `lint_sass()` now uses `stylelint` 14.16 (the last major version supporting stylistic rules)
     * Upgrade all remaining Node.js dependencies to latest versions and fix vulnerabilities.
     * The minimum supported Node.js version is now 16.
+4. `shiny.autoreload` now works correctly with `box::use`. Note: this requires
+   `legacy_entrypoint` to be unset.
 
 # [rhino 1.5.0](https://github.com/Appsilon/rhino/releases/tag/v1.5.0)
 

--- a/R/app.R
+++ b/R/app.R
@@ -41,6 +41,11 @@ load_main_module <- function() {
   main <- NULL
   box::use(app/main)
   main_env <- environment()
+  if (isTRUE(getOption("shiny.autoreload", FALSE))) {
+    shiny:::autoReloadCallbacks$register(function() {
+      evalq(box::reload(main), main_env)
+    })
+  }
   main_env
 }
 

--- a/R/app.R
+++ b/R/app.R
@@ -116,6 +116,8 @@ with_head_tags <- function(ui) {
 #' into a [Shiny module](https://shiny.rstudio.com/articles/modules.html)
 #' (functions taking a single `id` argument).
 #'
+#' Note: `legacy_entrypoint` might not work in conjunction with `shiny.autoreload`.
+#'
 #' @return An object representing the app (can be passed to `shiny::runApp()`).
 #'
 #' @examples

--- a/inst/as_top_level.R
+++ b/inst/as_top_level.R
@@ -1,12 +1,12 @@
 # This function is defined in the `inst` directory, as it must be sourced with `keep.source = TRUE`
 # for reloading to work: https://github.com/Appsilon/rhino/issues/157
-function(shiny_module) {
+function(shiny_module_env) {
   list(
     # Wrap the UI in a function to support Shiny bookmarking.
-    ui = function(request) shiny_module$ui("app"),
+    ui = function(request) shiny_module_env$main$ui("app"),
     # The curly braces below are essential: https://github.com/Appsilon/rhino/issues/157
     server = function(input, output) {
-      shiny_module$server("app")
+      shiny_module_env$main$server("app")
     }
   )
 }

--- a/man/app.Rd
+++ b/man/app.Rd
@@ -47,6 +47,8 @@ Compared to \code{box_top_level} you'll need to make your top-level \code{ui} an
 into a \href{https://shiny.rstudio.com/articles/modules.html}{Shiny module}
 (functions taking a single \code{id} argument).
 }
+
+Note: \code{legacy_entrypoint} might not work in conjunction with \code{shiny.autoreload}.
 }
 
 \examples{


### PR DESCRIPTION
⚠️ **Note:** these changes include using `:::`. I guess it needs a workaround for CRAN to accept it.

### Changes
Implements automatic reloading from #339.

With `shiny.autoreload` working I don't think we need to modify `shiny.autoreload.pattern`. Running `rhino::build_js(watch = TRUE)` and `rhino::build_sass(watch = TRUE)` outputs minified `.js` and `.css` files respectively. [Shiny by default tracks `.js` and `.css` changes][], so it will reload when either JS or CSS is built.

[Shiny by default tracks `.js` and `.css` changes]: https://github.com/rstudio/shiny/blob/v1.8.0/R/shinyapp.R#L294

### How to test
1. Install my forked version: `pak::pak("TymekDev/rhino@autoreload")`
1. _(Optional)_ Initialize a new application: `rhino::init()`
1. Enable autoreload: `options(shiny.autoreload = TRUE)`
1. Run the app: `shiny::runApp()` (`rhino::app` won't work!)

This will work in new and old apps alike. The only thing that changed is the main module is not passed directly. Instead, an environment where it was loaded with `box::use` is passed. This allows `box::reload` to work.