### PR TITLE
Only build & deploy pkgdown on release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,6 +45,16 @@ with write access to code and workflows.
 It should be saved as the `APP_PUSH_TEST_PAT`
 [repository secret](https://github.com/Appsilon/rhino/settings/secrets/actions).
 
+## Website
+
+The [documentation site](https://appsilon.github.io/rhino/)
+is built and deployed automatically by our [`pkgdown.yml`](workflows/pkgdown.yml) workflow.
+This workflow is triggered when a
+[release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+is published, or a pre-release is changed to a release.
+It is also possible to manually run it for a selected tag/branch
+from the [Actions](https://github.com/Appsilon/rhino/actions/workflows/pkgdown.yml) tab.
+
 ## Release process
 
 ### Preparation

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,7 +1,12 @@
 name: pkgdown
 on:
-  push:
-    branches: [main]
+  # Run when a release is published, or a pre-release is changed to a release. Reference:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+  # https://docs.github.com/en/webhooks/webhook-events-and-payloads#release
+  release:
+    types: [released]
+  # It is also possible to manually trigger this workflow for a selected tag/branch
+  # from the "Actions" tab on GitHub.
   workflow_dispatch:
 permissions:
   contents: write


### PR DESCRIPTION
### Changes

Closes #527:
1. Trigger our `pkgdown.yml` workflow on `release` instead of `push`. This way our website will show docs for the latest release instead of development version.
2. Document the change.

This should resolve our immediate problem of confusing users. Ideally we'd allow users select the documentation version to browse, but I haven't found any simple way to achieve it. I have summarized my research in a new issue: #530.

### How to test

We'll see if this works as expected when we release Rhino 1.6.

If needed, we can manually trigger the workflow for any tag/branch. I used this to deploy v1.5 docs now. I used a temporary branch (`tmp-docs-1.5`) instead of `v1.5.0` tag to include the CSS fix from #517.