### PR TITLE
Use sparse checkout in E2E workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -25,12 +25,13 @@ jobs:
         - {os: ubuntu-22.04, r: 'oldrel'}
 
     steps:
-      - name: Checkout E2E Directory
-        # Only checkout the necessary files; the DESCRIPTION file breaks test_r() due to Issue #461
-        uses: Bhacaz/checkout-files@v2
+      - name: Checkout E2E directory
+        uses: actions/checkout@v4
         with:
-          files: tests/e2e
-          branch: ${{ github.head_ref || github.ref_name }}
+          # Only checkout the necessary files; the DESCRIPTION file breaks test_r():
+          # https://github.com/Appsilon/rhino/issues/461
+          sparse-checkout: /tests/e2e/
+          sparse-checkout-cone-mode: false
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
### Changes

Use `actions/checkout@v4` with `sparse-checkout` instead of `Bhacaz/checkout-files@v2`, which is not very popular and doesn't seem to work on PRs originating from external repositories (problem encountered on #496).

### How to test

If the E2E workflow still passes, we should be good.