### PR TITLE
Lazy refactor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Suggests:
   mockery,
   rcmdcheck,
   rex,
+  rlang,
   rmarkdown,
   shiny.react,
   spelling

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.6.0.9003
+Version: 1.6.0.9004
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,11 @@
 1. Introduce linters for `box::use` statements:
     * `box_universal_import_linter` checks if all imports are explicit.
     * `box_trailing_commas_linter` checks if statements include trailing commas.
-2. Refactor `rhino::app()`.
-The `request` parameter is now correctly forwarded to the UI function
-when using a `legacy_entrypoint` ([#395](https://github.com/Appsilon/rhino/issues/395)).
+2. Major refactor of `rhino::app()`:
+    * The `request` parameter is now correctly forwarded to the UI function
+    when using a `legacy_entrypoint` ([#395](https://github.com/Appsilon/rhino/issues/395)).
+    * Force evaluation of arguments in higher-order functions
+    to avoid unexpected behavior due to lazy evaluation (internal).
 
 # [rhino 1.6.0](https://github.com/Appsilon/rhino/releases/tag/v1.6.0)
 

--- a/R/app.R
+++ b/R/app.R
@@ -132,6 +132,7 @@ normalize_main <- function(main, is_module = FALSE) {
 }
 
 normalize_ui <- function(ui, is_module = FALSE) {
+  force(ui) # Avoid the pitfalls of lazy evaluation.
   if (is_module) {
     function(request) ui("app")
   } else if (!is.function(ui)) {
@@ -144,6 +145,7 @@ normalize_ui <- function(ui, is_module = FALSE) {
 }
 
 normalize_server <- function(server, is_module = FALSE) {
+  force(server) # Avoid the pitfalls of lazy evaluation.
   if (is_module) {
     function(input, output, session) {
       server("app")
@@ -173,6 +175,7 @@ with_head_tags <- function(ui) {
     shiny::tags$link(rel = "stylesheet", href = "static/css/app.min.css", type = "text/css"),
     shiny::tags$link(rel = "icon", href = "static/favicon.ico", sizes = "any")
   )
+  force(ui) # Avoid the pitfalls of lazy evaluation.
   function(request) {
     shiny::tagList(head, ui(request))
   }

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -89,16 +89,22 @@ describe("with_head_tags()", {
   })
 })
 
-describe("reparse()", {
-  it("ensures a function has source reference information attached", {
-    f <- eval(
-      expr = parse(text = "function() 1", keep.source = FALSE),
-      envir = new.env(parent = baseenv())
-    )
-    g <- reparse(f)
+describe("fix_server()", {
+  it("ensures server uses curly braces and has source reference information attached", {
+    body_uses_curly_braces <- function(f) {
+      identical(body(f)[[1]], rlang::sym("{"))
+    }
 
-    expect_identical(f, g)
-    expect_false("srcref" %in% names(attributes(f)))
-    expect_true("srcref" %in% names(attributes(g)))
+    server <- eval(parse(
+      text = "function(input, output, session) 42",
+      keep.source = FALSE
+    ))
+    fixed <- fix_server(server)
+
+    expect_identical(fixed(), server())
+    expect_false(body_uses_curly_braces(server))
+    expect_true(body_uses_curly_braces(fixed))
+    expect_false("srcref" %in% names(attributes(server)))
+    expect_true("srcref" %in% names(attributes(fixed)))
   })
 })


### PR DESCRIPTION
### Changes

Last small refactor before introducing auto-reload:

1. Simplify and bundle the server reloading workaround in a single `fix_server` function.
2. Force the evaluation of arguments in higher-order functions to avoid the pitfalls of [lazy evaluation](https://adv-r.hadley.nz/functions.html#lazy-evaluation).

