### PR TITLE
Add support for `shiny.autoreload`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.6.0.9004
+Version: 1.6.0.9005
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
     when using a `legacy_entrypoint` ([#395](https://github.com/Appsilon/rhino/issues/395)).
     * Force evaluation of arguments in higher-order functions
     to avoid unexpected behavior due to lazy evaluation (internal).
+3. Add support for [`shiny.autoreload`](https://shiny.posit.co/r/reference/shiny/latest/shinyoptions).
 
 # [rhino 1.6.0](https://github.com/Appsilon/rhino/releases/tag/v1.6.0)
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -80,6 +80,15 @@ describe("normalize_server()", {
   })
 })
 
+describe("warn_on_error()", {
+  it("catches an error and prints it with an appended message", {
+    expect_message(
+      warn_on_error(stop("some_error"), "some_message"),
+      "some_message: some_error"
+    )
+  })
+})
+
 describe("with_head_tags()", {
   it("attaches a head tag to UI", {
     ui <- function(request) shiny::tags$div("test")

--- a/vignettes/faq.Rmd
+++ b/vignettes/faq.Rmd
@@ -20,6 +20,15 @@ You can run a Rhino application exactly the same as a regular Shiny app:
 </details>
 
 <details>
+<summary>How to automatically reload the application during development?</summary>
+
+Call `options(shiny.autoreload = TRUE)` in your R session.
+Shiny will monitor the app directory and reload all connected sessions if any changes are detected.
+More details can be found in [Shiny reference](https://shiny.posit.co/r/reference/shiny/latest/shinyoptions).
+
+</details>
+
+<details>
 <summary>How to use a specific port when running a Rhino application?</summary>
 
 You can:


### PR DESCRIPTION
### Changes

Supersedes PR #528, addresses issues #339, #552. Add support for automatic reloading with `options(shiny.autoreload = TRUE)`.

### How to test

Set `options(shiny.autoreload = TRUE)` and run a Rhino app. Modify e.g. `main.R` - the app should automatically reload and show the changes. It should work with all settings of `legacy_entrypoint` with the exclusion of `app_dir`.