### PR TITLE
ci: limit triggers to PRs, push to main, and a manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,10 @@
-on: [push, pull_request]
-
 name: E2E Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 defaults:
  run:


### PR DESCRIPTION
Inspired by https://github.com/Appsilon/shiny.semantic/pull/457/commits/b700ca0b49e2af3e5565282418621fe13434cd8b.

Shall we go ahead and update the triggers in the template Rhino creates for an end user?