### PR TITLE
chore: remove project-specific PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,0 @@
-### Changes
-Closes #
-
-### How to test


### PR DESCRIPTION
Upon removal, [an organization-wide template](https://github.com/Appsilon/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md) will be used. I have updated this template a while back to include Rhino definition of done, so I find using it would be fitting.