### PR TITLE
Add configuring lintr link

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -66,12 +66,14 @@ check_paths <- function(paths) {
   }
 }
 
+# nolint start: line_length_linter
 #' Lint R
 #'
 #' Uses the `{lintr}` package to check all R sources in the `app` and `tests/testthat` directories
 #' for style errors.
 #'
-#' The linter rules can be adjusted in the `.lintr` file.
+#' The linter rules can be [adjusted](https://lintr.r-lib.org/articles/lintr.html#configuring-linters)
+#' in the `.lintr` file.
 #'
 #' You can set the maximum number of accepted style errors
 #' with the `legacy_max_lint_r_errors` option in `rhino.yml`.
@@ -83,6 +85,7 @@ check_paths <- function(paths) {
 #' @return None. This function is called for side effects.
 #'
 #' @export
+# nolint end
 lint_r <- function(paths = NULL) {
   if (is.null(paths)) {
     paths <- c("app", "tests/testthat")

--- a/man/lint_r.Rd
+++ b/man/lint_r.Rd
@@ -18,7 +18,8 @@ Uses the \code{{lintr}} package to check all R sources in the \code{app} and \co
 for style errors.
 }
 \details{
-The linter rules can be adjusted in the \code{.lintr} file.
+The linter rules can be \href{https://lintr.r-lib.org/articles/lintr.html#configuring-linters}{adjusted}
+in the \code{.lintr} file.
 
 You can set the maximum number of accepted style errors
 with the \code{legacy_max_lint_r_errors} option in \code{rhino.yml}.

--- a/vignettes/explanation/rhino-style-guide.Rmd
+++ b/vignettes/explanation/rhino-style-guide.Rmd
@@ -13,6 +13,8 @@ These rules are designed to work alongside `tidyverse` conventions, providing cl
 
 For more details on how to use `box::use` statements, see [Explanation: Box modules](https://appsilon.github.io/rhino/articles/explanation/box-modules.html).
 
+For more details on how to configure linter rules in the `.lintr` file, see [Configuring linters](https://lintr.r-lib.org/articles/lintr.html#configuring-linters).
+
 # Explicit Import
 
 For clarity and ease of tracking function origins, avoid using `[...]` for imports. Explicitly declare all packages, modules and functions.


### PR DESCRIPTION
## Description
* Add configuring linters link in `rhino::lint_r()` and the Rhino style guide.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
