### PR TITLE
Prepare the package for further development

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -121,6 +121,7 @@ Use `rc.2`, `rc.3` and so on for subsequent submissions.
         * Link the `# rhino X.Y.Z` header to the GitHub release.
         * Add a link to the migration guide in `NEWS.md`.
 3. Announce the release on `#proj-rhino`.
+4. Complete the upgrade of Rhino Showcase.
 
 ## Development process
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.9.0
+Version: 1.9.0.9000
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# rhino 1.9.0
+# rhino (development version)
+
+# [rhino 1.9.0](https://github.com/Appsilon/rhino/releases/tag/v1.9.0)
+
+See _[How-to: Rhino 1.9 Migration Guide](https://appsilon.github.io/rhino/articles/how-to/migrate-1-9.html)_
 
 1. Added `sass: custom` configuration option for cleaner integration with `bslib`.
 2. Introduced `format_js()` and `format_sass()` powered by [prettier](https://prettier.io).
@@ -8,10 +12,10 @@
 
 # [rhino 1.8.0](https://github.com/Appsilon/rhino/releases/tag/v1.8.0)
 
+See _[How-to: Rhino 1.8 Migration Guide](https://appsilon.github.io/rhino/articles/how-to/migrate-1-8.html)_
+
 1. All linter functions migrated to `box.linters`. New rhino projects will be configured to use linters from `box.linters`.
 2. Updated GitHub Workflow template triggers.
-
-See _[How-to: Rhino 1.8 Migration Guide](https://appsilon.github.io/rhino/articles/how-to/migrate-1-8.html)_
 
 # [rhino 1.7.0](https://github.com/Appsilon/rhino/releases/tag/v1.7.0)
 

--- a/pkgdown/versions.yml
+++ b/pkgdown/versions.yml
@@ -1,8 +1,11 @@
 - git_ref: 'refs/remotes/origin/main'
   url: /dev
   label: true
-- git_ref: 'refs/tags/v1.8.0'
+- git_ref: 'refs/tags/v1.9.0'
   url: '/'
+  label: '1.9'
+- git_ref: 'refs/tags/v1.8.0'
+  url: '/v1.8.0'
   label: '1.8'
 - git_ref: 'refs/tags/v1.7.0'
   url: '/v1.7.0'


### PR DESCRIPTION
### Changes

1. Add a new version to `pkgdown/versions.yml`.
2. Set a development version in `DESCRIPTION`.
3. Update `NEWS.md`. Notes: moved the 1.8 migration guide to section top; the link for 1.9 should work once new docs are built (after this PR is merged).
4. Update release instructions: add "complete Showcase upgrade" point.