### PR TITLE
Add box.linters styling functions. add check for treesitter dependencies

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -50,9 +50,6 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: Appsilon/rhino@${{ github.sha }}
-          extra-packages: |
-            any::treesitter.r
-            any::treesitter
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -63,6 +60,11 @@ jobs:
         if: always()
         shell: Rscript {0}
         run: rhino::init('RhinoApp')
+
+      - name: Install treesitter dependencies
+        if: always()
+        shell: Rscript {0}
+        run: install.packages(c('treesitter', 'treesitter.r'))
 
       - name: diagnostics() should print system information and Rhino version
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install treesitter dependencies
         if: always()
         shell: Rscript {0}
-        run: install.packages(c('treesitter', 'treesitter.r'))
+        run: rhino::pkg_install('treesitter')
 
       - name: diagnostics() should print system information and Rhino version
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,11 +61,6 @@ jobs:
         shell: Rscript {0}
         run: rhino::init('RhinoApp')
 
-      - name: Install treesitter dependencies
-        if: always()
-        shell: Rscript {0}
-        run: rhino::pkg_install('treesitter')
-
       - name: diagnostics() should print system information and Rhino version
         if: always()
         shell: Rscript {0}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -50,6 +50,9 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: Appsilon/rhino@${{ github.sha }}
+          extra-packages: |
+            any::treesitter.r
+            any::treesitter
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.9.0.9000
+Version: 1.9.0.9001
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),
@@ -24,7 +24,7 @@ Depends:
   R (>= 2.10)
 Imports:
   box (>= 1.1.3),
-  box.linters (>= 0.9.1),
+  box.linters (>= 10.1.0),
   cli,
   config,
   fs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Depends:
   R (>= 2.10)
 Imports:
   box (>= 1.1.3),
-  box.linters (>= 0.10.2),
+  box.linters (>= 0.10.4),
   cli,
   config,
   fs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,12 +19,12 @@ BugReports: https://github.com/Appsilon/rhino/issues
 License: LGPL-3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends:
   R (>= 2.10)
 Imports:
   box (>= 1.1.3),
-  box.linters (>= 10.1.0),
+  box.linters (>= 0.10.2),
   cli,
   config,
   fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rhino (development version)
 
-* integrate {box.linters} styling functions
-* add compatibility check for `treesitter` and `treesitter.r` dependencies
+* Integrated {box.linters} styling functions to style `box::use()` calls according to the Rhino style guide.
+* Added compatibility check for `treesitter` and `treesitter.r` dependencies
 
 # [rhino 1.9.0](https://github.com/Appsilon/rhino/releases/tag/v1.9.0)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rhino (development version)
 
+* integrate {box.linters} styling functions
+* add compatibility check for `treesitter` and `treesitter.r` dependencies
+
 # [rhino 1.9.0](https://github.com/Appsilon/rhino/releases/tag/v1.9.0)
 
 See _[How-to: Rhino 1.9 Migration Guide](https://appsilon.github.io/rhino/articles/how-to/migrate-1-9.html)_

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -12,7 +12,7 @@ read_dependencies <- function() {
 }
 
 write_dependencies <- function(deps) {
-  if (getRversion() >= 4.3) {
+  if (as.numeric(R.Version()$major) >= 4 && as.numeric(R.Version()$minor) >= 3.0) {
     deps <- c(deps, "treesitter", "treesitter.r")
   }
   deps <- sort(unique(c("rhino", deps))) # Rhino is always needed as a dependency.

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -12,6 +12,9 @@ read_dependencies <- function() {
 }
 
 write_dependencies <- function(deps) {
+  if (getRversion() >= 4.3) {
+    deps <- c(deps, "treesitter", "treesitter.r")
+  }
   deps <- sort(unique(c("rhino", deps))) # Rhino is always needed as a dependency.
   deps <- purrr::map_chr(deps, function(name) glue::glue("library({name})"))
   deps <- c(

--- a/R/tools.R
+++ b/R/tools.R
@@ -167,7 +167,7 @@ rhino_style <- function() {
 format_r <- function(paths, exclude_files = c("__init__\\.R")) {
   style_box_use <- box.linters::style_box_use_dir
   if (!box.linters::is_treesitter_installed()) {
-    style_box_use <- function(path) { }
+    style_box_use <- function(path, exclude_files) { }
     cli::cli_warn(
       c(
         "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by some features of `format_r()`.", #nolint

--- a/R/tools.R
+++ b/R/tools.R
@@ -151,6 +151,8 @@ rhino_style <- function() {
 #'
 #'
 #' @param paths Character vector of files and directories to format.
+#' @param exclude_files Character vector with regular expressions of files that should be excluded
+#' from styling.
 #' @return None. This function is called for side effects.
 #'
 #' @examples
@@ -162,7 +164,7 @@ rhino_style <- function() {
 #'   format_r("app/view")
 #' }
 #' @export
-format_r <- function(paths) {
+format_r <- function(paths, exclude_files = c("__init__\\.R")) {
   style_box_use <- box.linters::style_box_use_dir
   if (!box.linters::is_treesitter_installed()) {
     style_box_use <- function(path) { }
@@ -176,10 +178,10 @@ format_r <- function(paths) {
 
   for (path in paths) {
     if (fs::is_dir(path)) {
-      style_box_use(path)
-      styler::style_dir(path, style = rhino_style)
+      style_box_use(path, exclude_files = exclude_files)
+      styler::style_dir(path, style = rhino_style, exclude_files = exclude_files)
     } else {
-      style_box_use(path)
+      style_box_use(path, exclude_files = exclude_files)
       styler::style_file(path, style = rhino_style)
     }
   }

--- a/R/tools.R
+++ b/R/tools.R
@@ -164,7 +164,7 @@ rhino_style <- function() {
 #'   format_r("app/view")
 #' }
 #' @export
-format_r <- function(paths, exclude_files = c("__init__\\.R")) {
+format_r <- function(paths, exclude_files = NULL) {
   style_box_use <- box.linters::style_box_use_dir
   if (!box.linters::is_treesitter_installed()) {
     style_box_use <- function(path, exclude_files) { }

--- a/R/tools.R
+++ b/R/tools.R
@@ -143,7 +143,12 @@ rhino_style <- function() {
 #' spacing around math operators is not modified to avoid conflicts with `box::use()` statements.
 #'
 #' `box.linters::style_*` functions require the `treesitter` and `treesitter.r` packages. These, in
-#' turn, require R >= 4.3.0.
+#' turn, require R >= 4.3.0. `box.linters` provides styling functions specific to the `box::use()`
+#' calls. These include:
+#' * Separate `box::use()` calls for packages and local modules
+#' * Alphabetically sorted packages, modules, and functions.
+#' * Trailing commas
+#'
 #'
 #' @param paths Character vector of files and directories to format.
 #' @return None. This function is called for side effects.
@@ -158,10 +163,12 @@ rhino_style <- function() {
 #' }
 #' @export
 format_r <- function(paths) {
+  style_box_use <- box.linters::style_box_use_dir
   if (!box.linters::is_treesitter_installed()) {
-    cli::cli_abort(
+    style_box_use <- function (path) { }
+    cli::cli_warn(
       c(
-        "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by `format_r()`",
+        "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by some features of `format_r()`.", #nolint
         "i" = "These package require R version >= 4.3.0 to install."
       )
     )
@@ -169,10 +176,10 @@ format_r <- function(paths) {
 
   for (path in paths) {
     if (fs::is_dir(path)) {
-      box.linters::style_box_use_dir(path)
+      style_box_use(path)
       styler::style_dir(path, style = rhino_style)
     } else {
-      box.linters::style_box_use_file(path)
+      style_box_use(path)
       styler::style_file(path, style = rhino_style)
     }
   }

--- a/R/tools.R
+++ b/R/tools.R
@@ -151,13 +151,13 @@ rhino_style <- function() {
 #' * Adding trailing commas
 #'
 #' `box.linters::style_*` functions require the `treesitter` and `treesitter.r` packages. These, in
-#' turn, require R >= 4.3.0. `format_r()` will continue to operate without these but will not perform `box::use()` call
-#' styling.
+#' turn, require R >= 4.3.0. `format_r()` will continue to operate without these but will not
+#' perform `box::use()` call styling.
 #'
 #' For more information on `box::use()` call styling please refer to the `{box.linters}` styling
 #' functions
 #' [documentation](https://appsilon.github.io/box.linters/reference/style_box_use_text.html).
-#' 
+#'
 #' @param paths Character vector of files and directories to format.
 #' @param exclude_files Character vector with regular expressions of files that should be excluded
 #' from styling.

--- a/R/tools.R
+++ b/R/tools.R
@@ -178,7 +178,7 @@ format_r <- function(paths, exclude_files = NULL) {
     style_box_use <- function(path, exclude_files) { }
     cli::cli_warn(
       c(
-        "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by some features of `format_r()`.", #nolint
+        "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by `box::use()` styling features of `format_r()`.", #nolint
         "i" = "These package require R version >= 4.3.0 to install."
       )
     )

--- a/R/tools.R
+++ b/R/tools.R
@@ -165,7 +165,7 @@ rhino_style <- function() {
 format_r <- function(paths) {
   style_box_use <- box.linters::style_box_use_dir
   if (!box.linters::is_treesitter_installed()) {
-    style_box_use <- function (path) { }
+    style_box_use <- function(path) { }
     cli::cli_warn(
       c(
         "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by some features of `format_r()`.", #nolint

--- a/R/tools.R
+++ b/R/tools.R
@@ -142,14 +142,20 @@ rhino_style <- function() {
 #' The code is formatted according to the `styler::tidyverse_style` guide with one adjustment:
 #' spacing around math operators is not modified to avoid conflicts with `box::use()` statements.
 #'
+#' If available, `box::use()` calls are reformatted by styling functions provided by
+#' `{box.linters}`. These include:
+#' * Separating `box::use()` calls for packages and local modules
+#' * Alphabetically sorting packages, modules, and functions.
+#' * Adding trailing commas
+#'
 #' `box.linters::style_*` functions require the `treesitter` and `treesitter.r` packages. These, in
 #' turn, require R >= 4.3.0. `box.linters` provides styling functions specific to the `box::use()`
-#' calls. These include:
-#' * Separate `box::use()` calls for packages and local modules
-#' * Alphabetically sorted packages, modules, and functions.
-#' * Trailing commas
-#'
-#'
+#' calls. 
+#' 
+#' For more information on `box::use()` call styling please refer to the `{box.linters}` styling
+#' functions
+#' [documentation](https://appsilon.github.io/box.linters/reference/style_box_use_text.html).
+#' 
 #' @param paths Character vector of files and directories to format.
 #' @param exclude_files Character vector with regular expressions of files that should be excluded
 #' from styling.

--- a/R/tools.R
+++ b/R/tools.R
@@ -137,21 +137,23 @@ rhino_style <- function() {
 
 #' Format R
 #'
-#' Uses the `{styler}` and `{box.linters}` packages to automatically format R sources.
+#' Uses the `{styler}` and `{box.linters}` packages to automatically format R sources. As with
+#' `styler`, carefully examine the results after running this function.
 #'
 #' The code is formatted according to the `styler::tidyverse_style` guide with one adjustment:
 #' spacing around math operators is not modified to avoid conflicts with `box::use()` statements.
 #'
 #' If available, `box::use()` calls are reformatted by styling functions provided by
 #' `{box.linters}`. These include:
+#'
 #' * Separating `box::use()` calls for packages and local modules
 #' * Alphabetically sorting packages, modules, and functions.
 #' * Adding trailing commas
 #'
 #' `box.linters::style_*` functions require the `treesitter` and `treesitter.r` packages. These, in
-#' turn, require R >= 4.3.0. `box.linters` provides styling functions specific to the `box::use()`
-#' calls. 
-#' 
+#' turn, require R >= 4.3.0. `format_r()` will continue to operate without these but will not perform `box::use()` call
+#' styling.
+#'
 #' For more information on `box::use()` call styling please refer to the `{box.linters}` styling
 #' functions
 #' [documentation](https://appsilon.github.io/box.linters/reference/style_box_use_text.html).

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -22,14 +22,21 @@ Uses the \code{{styler}} and \code{{box.linters}} packages to automatically form
 The code is formatted according to the \code{styler::tidyverse_style} guide with one adjustment:
 spacing around math operators is not modified to avoid conflicts with \code{box::use()} statements.
 
+If available, \code{box::use()} calls are reformatted by styling functions provided by
+\code{{box.linters}}. These include:
+\itemize{
+\item Separating \code{box::use()} calls for packages and local modules
+\item Alphabetically sorting packages, modules, and functions.
+\item Adding trailing commas
+}
+
 \verb{box.linters::style_*} functions require the \code{treesitter} and \code{treesitter.r} packages. These, in
 turn, require R >= 4.3.0. \code{box.linters} provides styling functions specific to the \code{box::use()}
-calls. These include:
-\itemize{
-\item Separate \code{box::use()} calls for packages and local modules
-\item Alphabetically sorted packages, modules, and functions.
-\item Trailing commas
-}
+calls.
+
+For more information on \code{box::use()} call styling please refer to the \code{{box.linters}} styling
+functions
+\href{https://appsilon.github.io/box.linters/reference/style_box_use_text.html}{documentation}.
 }
 \examples{
 if (interactive()) {

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -4,10 +4,13 @@
 \alias{format_r}
 \title{Format R}
 \usage{
-format_r(paths)
+format_r(paths, exclude_files = c("__init__\\\\.R"))
 }
 \arguments{
 \item{paths}{Character vector of files and directories to format.}
+
+\item{exclude_files}{Character vector with regular expressions of files that should be excluded
+from styling.}
 }
 \value{
 None. This function is called for side effects.

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -16,7 +16,8 @@ from styling.}
 None. This function is called for side effects.
 }
 \description{
-Uses the \code{{styler}} and \code{{box.linters}} packages to automatically format R sources.
+Uses the \code{{styler}} and \code{{box.linters}} packages to automatically format R sources. As with
+\code{styler}, carefully examine the results after running this function.
 }
 \details{
 The code is formatted according to the \code{styler::tidyverse_style} guide with one adjustment:
@@ -31,8 +32,8 @@ If available, \code{box::use()} calls are reformatted by styling functions provi
 }
 
 \verb{box.linters::style_*} functions require the \code{treesitter} and \code{treesitter.r} packages. These, in
-turn, require R >= 4.3.0. \code{box.linters} provides styling functions specific to the \code{box::use()}
-calls.
+turn, require R >= 4.3.0. \code{format_r()} will continue to operate without these but will not perform \code{box::use()} call
+styling.
 
 For more information on \code{box::use()} call styling please refer to the \code{{box.linters}} styling
 functions

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -32,8 +32,8 @@ If available, \code{box::use()} calls are reformatted by styling functions provi
 }
 
 \verb{box.linters::style_*} functions require the \code{treesitter} and \code{treesitter.r} packages. These, in
-turn, require R >= 4.3.0. \code{format_r()} will continue to operate without these but will not perform \code{box::use()} call
-styling.
+turn, require R >= 4.3.0. \code{format_r()} will continue to operate without these but will not
+perform \code{box::use()} call styling.
 
 For more information on \code{box::use()} call styling please refer to the \code{{box.linters}} styling
 functions

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -4,7 +4,7 @@
 \alias{format_r}
 \title{Format R}
 \usage{
-format_r(paths, exclude_files = c("__init__\\\\.R"))
+format_r(paths, exclude_files = NULL)
 }
 \arguments{
 \item{paths}{Character vector of files and directories to format.}

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -13,11 +13,14 @@ format_r(paths)
 None. This function is called for side effects.
 }
 \description{
-Uses the \code{{styler}} package to automatically format R sources.
+Uses the \code{{styler}} and \code{{box.linters}} packages to automatically format R sources.
 }
 \details{
 The code is formatted according to the \code{styler::tidyverse_style} guide with one adjustment:
 spacing around math operators is not modified to avoid conflicts with \code{box::use()} statements.
+
+\verb{box.linters::style_*} functions require the \code{treesitter} and \code{treesitter.r} packages. These, in
+turn, require R >= 4.3.0.
 }
 \examples{
 if (interactive()) {

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -20,7 +20,13 @@ The code is formatted according to the \code{styler::tidyverse_style} guide with
 spacing around math operators is not modified to avoid conflicts with \code{box::use()} statements.
 
 \verb{box.linters::style_*} functions require the \code{treesitter} and \code{treesitter.r} packages. These, in
-turn, require R >= 4.3.0.
+turn, require R >= 4.3.0. \code{box.linters} provides styling functions specific to the \code{box::use()}
+calls. These include:
+\itemize{
+\item Separate \code{box::use()} calls for packages and local modules
+\item Alphabetically sorted packages, modules, and functions.
+\item Trailing commas
+}
 }
 \examples{
 if (interactive()) {

--- a/man/lint_r.Rd
+++ b/man/lint_r.Rd
@@ -24,4 +24,8 @@ in the \code{.lintr} file.
 You can set the maximum number of accepted style errors
 with the \code{legacy_max_lint_r_errors} option in \code{rhino.yml}.
 This can be useful when inheriting legacy code with multiple styling issues.
+
+The \code{\link[box.linters:namespaced_function_calls]{box.linters::namespaced_function_calls()}} linter requires the \code{{treesitter}} and
+\code{{treesitter.r}} packages. These require R >= 4.3.0. \code{lint_r()} will continue to run and skip
+\code{namespaced_function_calls()} if its dependencies are not available.
 }

--- a/tests/e2e/test-lint-r.R
+++ b/tests/e2e/test-lint-r.R
@@ -1,3 +1,7 @@
+if (getRversion() >= 4.3) {
+  install.packages(c("treesitter", "treesitter.r"))
+}
+
 rhino::lint_r()
 # Create bad scripts and test if formatting returns the expected result
 test_file_path <- fs::path("app", "logic", "bad-style.R")

--- a/tests/e2e/test-lint-r.R
+++ b/tests/e2e/test-lint-r.R
@@ -1,6 +1,4 @@
-if (getRversion() >= 4.3) {
-  install.packages(c("treesitter", "treesitter.r"))
-}
+install.packages(c("treesitter", "treesitter.r"))
 
 rhino::lint_r()
 # Create bad scripts and test if formatting returns the expected result

--- a/vignettes/explanation/rhino-style-guide.Rmd
+++ b/vignettes/explanation/rhino-style-guide.Rmd
@@ -129,3 +129,42 @@ box::use(
   shiny[div, fluidPage, navbarPage, sidebarPanel, sidebarLayout, mainPanel, tabPanel, tabsetPanel, titlePanel],
 )
 ```
+
+# Automated Styling of `box::use()` calls
+
+As of Rhino version 1.10.0, `format_r()` includes styling for `box::use()` calls. This is provided by [`{box.linters}`](https://appsilon.github.io/box.linters/) version >= 0.10.4. As with [`{styler}`](https://styler.r-lib.org/), carefully examine the styling results after performing automated styling on your code.
+
+Automated styling covers some of the topics described above such as:
+
+* Separating `box::use()` calls for packages and local modules
+* Alphabetically sorting packages, modules, and functions.
+* Adding trailing commas
+
+```r
+# Original
+box::use(stringr[str_trim, str_pad], dplyr, app/logic/table)
+
+# Styled
+box::use(
+  dplyr,
+  stringr[str_pad, str_trim],
+)
+
+box::use(
+  app/logic/table
+)
+```
+
+## Requirements
+
+* R version >= 4.3.0
+* `box.linters` version >= 0.10.4
+* `treesitter` package
+* `treesitter.r` package
+
+## How to use
+
+1. `box::use()` call styling is included when running `format_r()`.
+2. It can also be separately executed by running one of the [`box.linters::style_*`](https://appsilon.github.io/box.linters/reference/index.html#box-styling) functions.
+
+For more information on the abilities of `{{box.linters}}` styling functions refer to the styling functions [documentation](https://appsilon.github.io/box.linters/reference/style_box_use_text.html).


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #606

## Description
* Adds box::use styling to format_r()
* Adds documentation for box::use styling

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
