### PR TITLE
Add check for box.lsp before applying languageserver options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.10.0.9000
+Version: 1.10.0.9001
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rhino (development version)
 
+* Added check for `box.lsp` package in `.Rprofile` before applying the `languageserver` options.
+
 # [rhino 1.10.0](https://github.com/Appsilon/rhino/releases/tag/v1.10.0)
 
 See _[How-to: Rhino 1.10 Migration Guide](https://appsilon.github.io/rhino/articles/how-to/migrate-1-10.html)_

--- a/inst/templates/renv/dot.Rprofile
+++ b/inst/templates/renv/dot.Rprofile
@@ -9,8 +9,10 @@ if (file.exists("renv")) {
 options(box.path = getwd())
 
 # box.lsp languageserver external hook
-options(
-  languageserver.parser_hooks = list(
-    "box::use" = box.lsp::box_use_parser
+if (nzchar(system.file(package = "box.lsp"))) {
+  options(
+    languageserver.parser_hooks = list(
+      "box::use" = box.lsp::box_use_parser
+    )
   )
-)
+}


### PR DESCRIPTION

Related to https://github.com/Appsilon/box.lsp/issues/28

## Description
* A rhino app project should now run CI without fail.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
