### PR TITLE
fix reference to style guide

### DIFF
--- a/vignettes/explanation/box-modules.Rmd
+++ b/vignettes/explanation/box-modules.Rmd
@@ -194,7 +194,7 @@ box::use(
 # Style guide
 
 To enhance the readability and maintainability of code,
-we suggest following [the Rhino style guide](https://appsilon.github.io/rhino/articles/explanation/rhino-styleguide.html).
+we suggest following [the Rhino style guide](https://appsilon.github.io/rhino/articles/explanation/rhino-style-guide.html).
 
 # Known issues
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Description
Fixed the reference to the styleguide page

## Definition of Done
- [X] The change is thoroughly documented.
- [X] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [X] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)

The docs are generated on CI/CD, so no other files were changed.
