### PR TITLE
Fix E2E tests in CI

### DIFF
--- a/R/react.R
+++ b/R/react.R
@@ -37,10 +37,10 @@ react_support <- function() {
 #'
 #' @examples
 #' # Declare the component.
-#' TextBox <- react_component("TextBox")
+#' TextBox <- try(react_component("TextBox"))
 #'
 #' # Use the component.
-#' ui <- TextBox("Hello!", font_size = 20)
+#' ui <- try(TextBox("Hello!", font_size = 20))
 #' @export
 # nolint end
 react_component <- function(name) {

--- a/man/react_component.Rd
+++ b/man/react_component.Rd
@@ -28,8 +28,8 @@ to learn about the details.
 }
 \examples{
 # Declare the component.
-TextBox <- react_component("TextBox")
+TextBox <- try(react_component("TextBox"))
 
 # Use the component.
-ui <- TextBox("Hello!", font_size = 20)
+ui <- try(TextBox("Hello!", font_size = 20))
 }

--- a/rhino.Rproj
+++ b/rhino.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 072963b7-26af-43ef-ac31-cf11cf7cf6ad
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/e2e/test-dependencies.R
+++ b/tests/e2e/test-dependencies.R
@@ -3,9 +3,6 @@ is_installed <- function(package) {
   length(find.package(package, quiet = TRUE)) > 0
 }
 
-# Use renv and install rhino
-renv::install()
-
 initial_dependencies <- readLines("dependencies.R")
 initial_lockfile <- readLines("renv.lock")
 
@@ -30,7 +27,7 @@ testthat::expect_contains(
 rhino::pkg_remove("dplyr")
 testthat::expect_false(is_installed("dplyr"))
 testthat::expect_identical(readLines("dependencies.R"), initial_dependencies)
-# testthat::expect_identical(readLines("renv.lock"), initial_lockfile)
+testthat::expect_identical(readLines("renv.lock"), initial_lockfile)
 
 # install package from GitHub
 

--- a/tests/e2e/test-dependencies.R
+++ b/tests/e2e/test-dependencies.R
@@ -3,6 +3,9 @@ is_installed <- function(package) {
   length(find.package(package, quiet = TRUE)) > 0
 }
 
+# Use renv and install rhino
+renv::install()
+
 initial_dependencies <- readLines("dependencies.R")
 initial_lockfile <- readLines("renv.lock")
 
@@ -27,7 +30,7 @@ testthat::expect_contains(
 rhino::pkg_remove("dplyr")
 testthat::expect_false(is_installed("dplyr"))
 testthat::expect_identical(readLines("dependencies.R"), initial_dependencies)
-testthat::expect_identical(readLines("renv.lock"), initial_lockfile)
+# testthat::expect_identical(readLines("renv.lock"), initial_lockfile)
 
 # install package from GitHub
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Description
This pull request was made solely to run the CI pipeline so I can debug the error.

When running `check` locally, RStudio pointed to on an example in `react_component` when the package `shiny.react` is not installed. Following [the R Packages book](https://r-pkgs.org/man.html#sec-man-examples-errors) it was suggested to put this example inside a `try` block OR use a `\dontrun{` flag.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
