### PR TITLE
ci: Install the last working version of renv in E2E.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: Appsilon/rhino@${{ github.sha }}
+          packages: | # A temporary workaround for https://github.com/rstudio/renv/issues/2109
+            renv@1.0.11
+            Appsilon/rhino@${{ github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Use the last working version of `renv` in E2E CI. A workaround for https://github.com/rstudio/renv/issues/2109