### PR TITLE
ci: Remove hardcoded version renv from e2e tests.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -49,8 +49,7 @@ jobs:
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: | # A temporary workaround for https://github.com/rstudio/renv/issues/2109
-            renv@1.0.11
+          packages: |
             Appsilon/rhino@${{ github.sha }}
 
       - name: Setup Node


### PR DESCRIPTION
## Description
Removes the hardcoded `renv` version workaround in E2E tests.

## Definition of Done
- [ ] The change is thoroughly documented.
- [x] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
