### PR TITLE
Bugfix for format_r() and single files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rhino
 Title: A Framework for Enterprise Shiny Applications
-Version: 1.10.1.9002
+Version: 1.10.1.9003
 Authors@R:
   c(
     person("Kamil", "Żyła", role = c("aut", "cre"), email = "opensource+kamil@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 1. Added destructure operator `%<-%`.
 2. `test_r` accepts additional arguments passed to `testthat::test_dir`.
+3. Bugfix for `format_r()` and single files. (#625)
 
 # [rhino 1.10.1](https://github.com/Appsilon/rhino/releases/tag/v1.10.1)
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -165,6 +165,7 @@ rhino_style <- function() {
 #' @param paths Character vector of files and directories to format.
 #' @param exclude_files Character vector with regular expressions of files that should be excluded
 #' from styling.
+#' @param ... Optional arguments to pass to `box.linters::style_*` functions.
 #' @return None. This function is called for side effects.
 #'
 #' @examples
@@ -176,10 +177,12 @@ rhino_style <- function() {
 #'   format_r("app/view")
 #' }
 #' @export
-format_r <- function(paths, exclude_files = NULL) {
-  style_box_use <- box.linters::style_box_use_dir
+format_r <- function(paths, exclude_files = NULL, ...) {
+  style_box_use_dir <- box.linters::style_box_use_dir
+  style_box_use_file <- box.linters::style_box_use_file
   if (!box.linters::is_treesitter_installed()) {
-    style_box_use <- function(path, exclude_files) { }
+    style_box_use_dir <- function(path, exclude_files, ...) { }
+    style_box_use_file <- function(path, ...) { }
     cli::cli_warn(
       c(
         "x" = "The packages {{treesitter}} and {{treesitter.r}} are required by `box::use()` styling features of `format_r()`.", #nolint
@@ -190,10 +193,10 @@ format_r <- function(paths, exclude_files = NULL) {
 
   for (path in paths) {
     if (fs::is_dir(path)) {
-      style_box_use(path, exclude_files = exclude_files)
+      style_box_use_dir(path, exclude_files = exclude_files, ...)
       styler::style_dir(path, style = rhino_style, exclude_files = exclude_files)
     } else {
-      style_box_use(path, exclude_files = exclude_files)
+      style_box_use_file(path, ...)
       styler::style_file(path, style = rhino_style)
     }
   }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,7 @@
 Addin
 Addins
 Appsilon
+Bugfix
 Destructure
 ESLint
 Init

--- a/man/format_r.Rd
+++ b/man/format_r.Rd
@@ -4,13 +4,15 @@
 \alias{format_r}
 \title{Format R}
 \usage{
-format_r(paths, exclude_files = NULL)
+format_r(paths, exclude_files = NULL, ...)
 }
 \arguments{
 \item{paths}{Character vector of files and directories to format.}
 
 \item{exclude_files}{Character vector with regular expressions of files that should be excluded
 from styling.}
+
+\item{...}{Optional arguments to pass to \verb{box.linters::style_*} functions.}
 }
 \value{
 None. This function is called for side effects.

--- a/rhino.Rproj
+++ b/rhino.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d115d13b-053e-44b1-ae8b-af45c16fec84
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Closes #625

## Description
* There was indeed a mistake in the code. `style_box_use` was an alias to `box.linters::style_box_use_dir()`.
* An odd behavior was occurring inside `format_r()`. With `app/main.R`, `fs::is_dir(path)` resolves to FALSE, which is correct. However, walking through the code, R would take the truthy branch rather than the falsey branch. By addressing the first mistake, this unusual behavior was also resolved. Interpreter got confused?

```r
# format_r()
# ...
    if (fs::is_dir(path)) {
      style_box_use(path, exclude_files = exclude_files)
      styler::style_dir(path, style = rhino_style, exclude_files = exclude_files)
    } else {
      style_box_use(path, exclude_files = exclude_files)
      styler::style_file(path, style = rhino_style)
    }
```

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
